### PR TITLE
cwnd reduction on congestion event

### DIFF
--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -426,7 +426,7 @@ cwnd, and ssthresh as follows. Parameter beta_cubic SHOULD be set to
     W_max = cwnd                 // save window size before reduction
     ssthresh = cwnd * beta_cubic // new slow-start threshold
     ssthresh = max(ssthresh, 2)  // threshold is at least 2 MSS
-    cwnd = cwnd * beta_cubic     // window reduction
+    cwnd = ssthresh              // window reduction
 ~~~
 
 A side effect of setting beta_cubic to a value bigger than 0.5 is


### PR DESCRIPTION
This change ensures that cwnd can now be less than 2. Resolves https://github.com/NTAP/rfc8312bis/issues/7