### PR TITLE
highlight the difference from the original paper and RFC8312

### DIFF
--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -115,7 +115,8 @@ informative:
     - name: Injong Rhee
 
   SXEZ19:
-    title: Model-Agnostic and Efficient Exploration of Numerical State Space of Real-World TCP Congestion Control Implementations
+    title: Model-Agnostic and Efficient Exploration of Numerical State Space of
+Real-World TCP Congestion Control Implementations
     date: 2019
     seriesinfo:
       USENIX NSDI: 2019
@@ -124,7 +125,6 @@ informative:
     - name: Lisong Xu
     - name: Sebastian Elbaum
     - name: Di Zhao
-
 
   CEHRX07:  DOI.10.1109/INFCOM.2007.111
   HRX08:    DOI.10.1145/1400097.1400105

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -117,6 +117,7 @@ informative:
   CEHRX07:  DOI.10.1109/INFCOM.2007.111
   HRX08:    DOI.10.1145/1400097.1400105
   K03:      DOI.10.1145/956981.956989
+  SXEZ19:  DOI.10.5555/3323234.3323292
 
 --- abstract
 
@@ -802,6 +803,53 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 <!-- Anyone else to acknowledge? -->
 
+# History of changes since the original paper
+
+CUBIC has gone through a few changes since the initial release of its 
+algorithm and implementation. Below we highlight the differences 
+between its original paper and RFCs.
+
+## The current draft
+
+- The list of variables and constants used for CUBIC has been added. 
+- K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the 
+RFC8312 it was cubic_root(W_max * (1-beta_cubic)/C).
+- When W_est <= W_max, TCP friendly window emulates Standard TCP's 
+throughput using segments or bytes received instead of time t. 
+When W_est > W_max, it sets alpha_aimd to 1.
+- The bugs reported in {{?SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT) 
+as the target window size after the next RTT. However, this target may be 
+too high, like even higher than 2 * cwnd (i.e., more aggressive than slow 
+start) in the following cases: (1) RTT is extremely long; (2) after a long 
+idle period; and (3) after a long application rate-limited period. 
+To address this issue, CUBIC now has lower and upper bounds to ensure that 
+the window increase rate is non-decreasing and is less than the increase 
+rate of slow start.
+
+## RFC 8312
+
+- It changed the definition of beta_cubic constant and thus updated the 
+pseudocode of CUBIC accordingly. For example, beta_cubic in the original 
+paper was the window decrease constant while RFC8312 changed it to CUBIC 
+multiplication decrease factor. With this change, the current congestion 
+window size after a loss event is beta_cubic * W_max while it was 
+(1-beta_cubic) * W_max in the original paper.
+- It used W_max while the original paper's pseudocode used W_last_max.
+- TCP friendly window is called W_est in RFC8312, whereas it was W_tcp in 
+the original paper.
+- It included the discussion on safety features of CUBIC, such as CUBIC's 
+fairness in small and high bandwidth-delay product (BDP) networks and the 
+recommended CUBIC constant C.
+
+## Original paper
+
+- The original paper included the pseudocode of CUBIC implementation using 
+Linux's pluggable congestion control framework, which excludes system-specific 
+optimizations. The simplified pseudocode might be a good source to start with 
+and understand CUBIC.
+- It also includes experimental results showing its performance and fairness.
+
+
 # Changes from RFC8312
 
 <!-- For future PRs, please include a bullet below that summarizes the change
@@ -816,6 +864,7 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 - update W_est to use AIMD approach (#20)
 - set alpha_aimd to 1 once W_est reaches W_max (#2)
 - add Vidhi as co-author (#17)
+- highlight difference to paper (#10)
 
 ## Since RFC8312
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -38,6 +38,15 @@ author:
   email: sangtae.ha@colorado.edu
   uri: "https://netstech.org/sangtaeha/"
 -
+  name: Vidhi Goel
+  org: Apple Inc.
+  street: One Apple Park Way
+  city: Cupertino
+  region: California
+  code: 95014
+  country: USA
+  email: vidhi_goel@apple.com
+-
   name: Lars Eggert
   org: NetApp
   street: Stenbergintie 12 B
@@ -806,6 +815,7 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 - update K's definition and add bounds for CUBIC target cwnd (#1, #14)
 - update W_est to use AIMD approach (#20)
 - set alpha_aimd to 1 once W_est reaches W_max (#2)
+- add Vidhi as co-author (#17)
 
 ## Since RFC8312
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -805,50 +805,49 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 # History of changes since the original paper
 
-CUBIC has gone through a few changes since the initial release of its 
-algorithm and implementation. Below we highlight the differences 
+CUBIC has gone through a few changes since the initial release of its
+algorithm and implementation. Below we highlight the differences
 between its original paper and RFCs.
 
 ## The current draft
 
-- The list of variables and constants used for CUBIC has been added. 
-- K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the 
+- The list of variables and constants used for CUBIC has been added.
+- K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the
 RFC8312 it was cubic_root(W_max * (1-beta_cubic)/C).
-- When W_est <= W_max, TCP friendly window emulates Standard TCP's 
-throughput using segments or bytes received instead of time t. 
+- When W_est <= W_max, TCP friendly window emulates Standard TCP's
+throughput using segments or bytes received instead of time t.
 When W_est > W_max, it sets alpha_aimd to 1.
-- The bugs reported in {{?SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT) 
-as the target window size after the next RTT. However, this target may be 
-too high, like even higher than 2 * cwnd (i.e., more aggressive than slow 
-start) in the following cases: (1) RTT is extremely long; (2) after a long 
-idle period; and (3) after a long application rate-limited period. 
-To address this issue, CUBIC now has lower and upper bounds to ensure that 
-the window increase rate is non-decreasing and is less than the increase 
+- The bugs reported in {{?SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT)
+as the target window size after the next RTT. However, this target may be
+too high, like even higher than 2 * cwnd (i.e., more aggressive than slow
+start) in the following cases: (1) RTT is extremely long; (2) after a long
+idle period; and (3) after a long application rate-limited period.
+To address this issue, CUBIC now has lower and upper bounds to ensure that
+the window increase rate is non-decreasing and is less than the increase
 rate of slow start.
 
 ## RFC 8312
 
-- It changed the definition of beta_cubic constant and thus updated the 
-pseudocode of CUBIC accordingly. For example, beta_cubic in the original 
-paper was the window decrease constant while RFC8312 changed it to CUBIC 
-multiplication decrease factor. With this change, the current congestion 
-window size after a loss event is beta_cubic * W_max while it was 
+- It changed the definition of beta_cubic constant and thus updated the
+pseudocode of CUBIC accordingly. For example, beta_cubic in the original
+paper was the window decrease constant while RFC8312 changed it to CUBIC
+multiplication decrease factor. With this change, the current congestion
+window size after a loss event is beta_cubic * W_max while it was
 (1-beta_cubic) * W_max in the original paper.
 - It used W_max while the original paper's pseudocode used W_last_max.
-- TCP friendly window is called W_est in RFC8312, whereas it was W_tcp in 
+- TCP friendly window is called W_est in RFC8312, whereas it was W_tcp in
 the original paper.
-- It included the discussion on safety features of CUBIC, such as CUBIC's 
-fairness in small and high bandwidth-delay product (BDP) networks and the 
+- It included the discussion on safety features of CUBIC, such as CUBIC's
+fairness in small and high bandwidth-delay product (BDP) networks and the
 recommended CUBIC constant C.
 
 ## Original paper
 
-- The original paper included the pseudocode of CUBIC implementation using 
-Linux's pluggable congestion control framework, which excludes system-specific 
-optimizations. The simplified pseudocode might be a good source to start with 
+- The original paper included the pseudocode of CUBIC implementation using
+Linux's pluggable congestion control framework, which excludes system-specific
+optimizations. The simplified pseudocode might be a good source to start with
 and understand CUBIC.
 - It also includes experimental results showing its performance and fairness.
-
 
 # Changes from RFC8312
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -114,18 +114,6 @@ informative:
     - name: Khaled Harfoush
     - name: Injong Rhee
 
-  SXEZ19:
-    title: Model-Agnostic and Efficient Exploration of Numerical State Space of
-Real-World TCP Congestion Control Implementations
-    date: 2019
-    seriesinfo:
-      USENIX NSDI: 2019
-    author:
-    - name: Wei Sun
-    - name: Lisong Xu
-    - name: Sebastian Elbaum
-    - name: Di Zhao
-
   CEHRX07:  DOI.10.1109/INFCOM.2007.111
   HRX08:    DOI.10.1145/1400097.1400105
   K03:      DOI.10.1145/956981.956989
@@ -819,7 +807,7 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 # History of Changes Since the Original Paper
 
-CUBIC has gone through a few changes since the initial release {{!HRX08}}
+CUBIC has gone through a few changes since the initial release {{?HRX08}}
 of its algorithm and implementation. Below we highlight the differences
 between its original paper and RFCs.
 
@@ -831,7 +819,7 @@ between its original paper and RFCs.
 - When W_est <= W_max, TCP friendly window emulates Standard TCP's
 throughput using segments or bytes received instead of time t.
 When W_est > W_max, it sets alpha_aimd to 1.
-- The bugs reported in {{?SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT)
+- The bugs reported are fixed. CUBIC sets W_cubic(t + RTT)
 as the target window size after the next RTT. However, this target may be
 too high, like even higher than 2 * cwnd (i.e., more aggressive than slow
 start) in the following cases: (1) RTT is extremely long; (2) after a long
@@ -857,7 +845,7 @@ recommended CUBIC constant C.
 
 ## Original Paper
 
-- The original paper {{!HRX08}} included the pseudocode of CUBIC implementation
+- The original paper {{?HRX08}} included the pseudocode of CUBIC implementation
 using Linux's pluggable congestion control framework, which excludes system-specific
 optimizations. The simplified pseudocode might be a good source to start with
 and understand CUBIC.

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -818,52 +818,6 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 <!-- Anyone else to acknowledge? -->
 
-# History of Changes Since the Original Paper
-
-CUBIC has gone through a few changes since the initial release {{HRX08}}
-of its algorithm and implementation. Below we highlight the differences
-between its original paper and RFCs.
-
-## The Current Draft
-
-- The list of variables and constants used for CUBIC has been added.
-- K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the
-{{?RFC8312}} it was cubic_root(W_max * (1-beta_cubic)/C).
-- When W_est <= W_max, TCP friendly window emulates Standard TCP's
-throughput using segments or bytes received instead of time t.
-When W_est > W_max, it sets alpha_aimd to 1.
-- The bugs reported in {{SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT)
-as the target window size after the next RTT. However, this target may be
-too high, like even higher than 2 * cwnd (i.e., more aggressive than slow
-start) in the following cases: (1) RTT is extremely long; (2) after a long
-idle period; and (3) after a long application rate-limited period.
-To address this issue, CUBIC now has lower and upper bounds to ensure that
-the window increase rate is non-decreasing and is less than the increase
-rate of slow start.
-
-## RFC 8312
-
-- It changed the definition of beta_cubic constant and thus updated the
-pseudocode of CUBIC accordingly. For example, beta_cubic in the original
-paper was the window decrease constant while {{!RFC8312}} changed it to CUBIC
-multiplication decrease factor. With this change, the current congestion
-window size after a loss event is beta_cubic * W_max while it was
-(1-beta_cubic) * W_max in the original paper.
-- It used W_max while the original paper's pseudocode used W_last_max.
-- TCP friendly window is called W_est in {{!RFC8312}}, whereas it was W_tcp in
-the original paper.
-- It included the discussion on safety features of CUBIC, such as CUBIC's
-fairness in small and high bandwidth-delay product (BDP) networks and the
-recommended CUBIC constant C.
-
-## Original Paper
-
-- The original paper {{HRX08}} included the pseudocode of CUBIC implementation
-using Linux's pluggable congestion control framework, which excludes system-specific
-optimizations. The simplified pseudocode might be a good source to start with
-and understand CUBIC.
-- It also includes experimental results showing its performance and fairness.
-
 # Changes from RFC8312
 
 <!-- For future PRs, please include a bullet below that summarizes the change
@@ -873,10 +827,20 @@ and understand CUBIC.
 
 - acknowledge former co-authors (#15)
 - prevent cwnd from becoming less than two (#7)
-- add list of variables and constants (#5, #6)
-- update K's definition and add bounds for CUBIC target cwnd (#1, #14)
-- update W_est to use AIMD approach (#20)
-- set alpha_aimd to 1 once W_est reaches W_max (#2)
+- The list of variables and constants used for CUBIC has been added (#5, #6)
+- K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the
+{{?RFC8312}} it was cubic_root(W_max * (1-beta_cubic)/C) (#1)
+- The bugs reported in {{SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT)
+as the target window size after the next RTT. However, this target may be
+too high, like even higher than 2 * cwnd (i.e., more aggressive than slow
+start) in the following cases: (1) RTT is extremely long; (2) after a long
+idle period; and (3) after a long application rate-limited period.
+To address this issue, CUBIC now has lower and upper bounds to ensure that
+the window increase rate is non-decreasing and is less than the increase
+rate of slow start (#14)
+- When W_est <= W_max, TCP friendly window emulates Standard TCP's
+throughput using segments or bytes received instead of time t (#20).
+When W_est > W_max, it sets alpha_aimd to 1 (#2).
 - add Vidhi as co-author (#17)
 - highlight difference to paper (#10)
 - note for fast recovery during cwnd decrease due to congestion event (#11)
@@ -888,3 +852,22 @@ and understand CUBIC.
 - updated author information
 - various whitespace changes
 - move to Standards Track
+
+# Changes from the Original Paper
+
+CUBIC has gone through a few changes since the initial release {{HRX08}}
+of its algorithm and implementation. Below we highlight the differences
+between its original paper and {{?RF8312}}.
+
+- The original paper {{HRX08}} included the pseudocode of CUBIC implementation
+using Linux's pluggable congestion control framework, which excludes system-specific
+optimizations. The simplified pseudocode might be a good source to start with
+and understand CUBIC.
+- It also includes experimental results showing its performance and fairness.
+- The definition of beta_cubic constant was changed in {{?RFC8312}}.
+For example, beta_cubic in the original paper was the window decrease constant
+while {{?RFC8312}} changed it to CUBIC multiplication decrease factor.
+With this change, the current congestion window size after a loss event in {{?RF8312}
+was beta_cubic * W_max while it was (1-beta_cubic) * W_max in the original paper.
+- Its pseudocode used W_last_max while {{?RF8312}} used W_max.
+- Its TCP friendly window was W_tcp while {{?RF8312}} used W_est.

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -857,7 +857,7 @@ When W_est > W_max, it sets alpha_aimd to 1 (#2).
 
 CUBIC has gone through a few changes since the initial release {{HRX08}}
 of its algorithm and implementation. Below we highlight the differences
-between its original paper and {{?RF8312}}.
+between its original paper and {{?RFC8312}}.
 
 - The original paper {{HRX08}} included the pseudocode of CUBIC implementation
 using Linux's pluggable congestion control framework, which excludes system-specific
@@ -867,7 +867,7 @@ and understand CUBIC.
 - The definition of beta_cubic constant was changed in {{?RFC8312}}.
 For example, beta_cubic in the original paper was the window decrease constant
 while {{?RFC8312}} changed it to CUBIC multiplication decrease factor.
-With this change, the current congestion window size after a loss event in {{?RF8312}
+With this change, the current congestion window size after a loss event in {{?RFC8312}}
 was beta_cubic * W_max while it was (1-beta_cubic) * W_max in the original paper.
-- Its pseudocode used W_last_max while {{?RF8312}} used W_max.
-- Its TCP friendly window was W_tcp while {{?RF8312}} used W_est.
+- Its pseudocode used W_last_max while {{?RFC8312}} used W_max.
+- Its TCP friendly window was W_tcp while {{?RFC8312}} used W_est.

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -114,10 +114,21 @@ informative:
     - name: Khaled Harfoush
     - name: Injong Rhee
 
+  SXEZ19:
+    title: Model-Agnostic and Efficient Exploration of Numerical State Space of Real-World TCP Congestion Control Implementations
+    date: 2019
+    seriesinfo:
+      USENIX NSDI: 2019
+    author:
+    - name: Wei Sun
+    - name: Lisong Xu
+    - name: Sebastian Elbaum
+    - name: Di Zhao
+
+
   CEHRX07:  DOI.10.1109/INFCOM.2007.111
   HRX08:    DOI.10.1145/1400097.1400105
   K03:      DOI.10.1145/956981.956989
-  SXEZ19:  DOI.10.5555/3323234.3323292
 
 --- abstract
 
@@ -803,17 +814,17 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 <!-- Anyone else to acknowledge? -->
 
-# History of changes since the original paper
+# History of Changes Since the Original Paper
 
-CUBIC has gone through a few changes since the initial release of its
-algorithm and implementation. Below we highlight the differences
+CUBIC has gone through a few changes since the initial release {{!HRX08}}
+of its algorithm and implementation. Below we highlight the differences
 between its original paper and RFCs.
 
-## The current draft
+## The Current Draft
 
 - The list of variables and constants used for CUBIC has been added.
 - K formula has changed to cubic_root((W_max - cwnd)/C) whereas in the
-RFC8312 it was cubic_root(W_max * (1-beta_cubic)/C).
+{{?RFC8312}} it was cubic_root(W_max * (1-beta_cubic)/C).
 - When W_est <= W_max, TCP friendly window emulates Standard TCP's
 throughput using segments or bytes received instead of time t.
 When W_est > W_max, it sets alpha_aimd to 1.
@@ -830,21 +841,21 @@ rate of slow start.
 
 - It changed the definition of beta_cubic constant and thus updated the
 pseudocode of CUBIC accordingly. For example, beta_cubic in the original
-paper was the window decrease constant while RFC8312 changed it to CUBIC
+paper was the window decrease constant while {{!RFC8312}} changed it to CUBIC
 multiplication decrease factor. With this change, the current congestion
 window size after a loss event is beta_cubic * W_max while it was
 (1-beta_cubic) * W_max in the original paper.
 - It used W_max while the original paper's pseudocode used W_last_max.
-- TCP friendly window is called W_est in RFC8312, whereas it was W_tcp in
+- TCP friendly window is called W_est in {{!RFC8312}}, whereas it was W_tcp in
 the original paper.
 - It included the discussion on safety features of CUBIC, such as CUBIC's
 fairness in small and high bandwidth-delay product (BDP) networks and the
 recommended CUBIC constant C.
 
-## Original paper
+## Original Paper
 
-- The original paper included the pseudocode of CUBIC implementation using
-Linux's pluggable congestion control framework, which excludes system-specific
+- The original paper {{!HRX08}} included the pseudocode of CUBIC implementation
+using Linux's pluggable congestion control framework, which excludes system-specific
 optimizations. The simplified pseudocode might be a good source to start with
 and understand CUBIC.
 - It also includes experimental results showing its performance and fairness.

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -114,6 +114,19 @@ informative:
     - name: Khaled Harfoush
     - name: Injong Rhee
 
+  SXEZ19:
+    title:
+      Model-Agnostic and Efficient Exploration of Numerical State Space of
+      Real-World TCP Congestion Control Implementations
+    date: 2019
+    seriesinfo:
+      USENIX NSDI: 2019
+    author:
+    - name: Wei Sun
+    - name: Lisong Xu
+    - name: Sebastian Elbaum
+    - name: Di Zhao
+
   CEHRX07:  DOI.10.1109/INFCOM.2007.111
   HRX08:    DOI.10.1145/1400097.1400105
   K03:      DOI.10.1145/956981.956989
@@ -149,7 +162,7 @@ draft can be found at [](https://github.com/NTAP/rfc8312bis).
 # Introduction
 
 The low utilization problem of TCP in fast long-distance networks is
-well documented in {{?K03}} and {{?RFC3649}}. This problem arises from a
+well documented in {{K03}} and {{?RFC3649}}. This problem arises from a
 slow increase of the congestion window following a congestion event
 in a network with a large bandwidth-delay product (BDP). {{HKLRX06}}
 indicates that this problem is frequently observed even in the range
@@ -160,7 +173,7 @@ their variants, including TCP-Reno {{!RFC5681}}, TCP-NewReno
 use the same linear increase function for window growth, which we refer to
 collectively as "Standard TCP" below.
 
-CUBIC, originally proposed in {{?HRX08}}, is a modification to the
+CUBIC, originally proposed in {{HRX08}}, is a modification to the
 congestion control algorithm of Standard TCP to remedy this problem.
 This document describes the most recent specification of CUBIC.
 Specifically, CUBIC uses a cubic function instead of a linear window
@@ -214,7 +227,7 @@ decrease factor in order to balance between the scalability and
 convergence speed.
 
 Principle 1: For better network utilization and stability, CUBIC
-{{?HRX08}} uses a cubic window increase function in terms of the elapsed
+{{HRX08}} uses a cubic window increase function in terms of the elapsed
 time from the last congestion event. While most alternative
 congestion control algorithms to Standard TCP increase the congestion
 window using convex functions, CUBIC uses both the concave and convex
@@ -230,7 +243,7 @@ W_max so that the concave window increase continues until the window
 size becomes W_max. After that, the cubic function turns into a
 convex profile and the convex window increase begins. This style of
 window adjustment (concave and then convex) improves the algorithm
-stability while maintaining high network utilization {{?CEHRX07}}. This
+stability while maintaining high network utilization {{CEHRX07}}. This
 is because the window size remains almost constant, forming a plateau
 around W_max where network utilization is deemed highest. Under
 steady state, most window size samples of CUBIC are close to W_max,
@@ -807,7 +820,7 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 # History of Changes Since the Original Paper
 
-CUBIC has gone through a few changes since the initial release {{?HRX08}}
+CUBIC has gone through a few changes since the initial release {{HRX08}}
 of its algorithm and implementation. Below we highlight the differences
 between its original paper and RFCs.
 
@@ -819,7 +832,7 @@ between its original paper and RFCs.
 - When W_est <= W_max, TCP friendly window emulates Standard TCP's
 throughput using segments or bytes received instead of time t.
 When W_est > W_max, it sets alpha_aimd to 1.
-- The bugs reported are fixed. CUBIC sets W_cubic(t + RTT)
+- The bugs reported in {{SXEZ19}} are fixed. CUBIC sets W_cubic(t + RTT)
 as the target window size after the next RTT. However, this target may be
 too high, like even higher than 2 * cwnd (i.e., more aggressive than slow
 start) in the following cases: (1) RTT is extremely long; (2) after a long
@@ -845,7 +858,7 @@ recommended CUBIC constant C.
 
 ## Original Paper
 
-- The original paper {{?HRX08}} included the pseudocode of CUBIC implementation
+- The original paper {{HRX08}} included the pseudocode of CUBIC implementation
 using Linux's pluggable congestion control framework, which excludes system-specific
 optimizations. The simplified pseudocode might be a good source to start with
 and understand CUBIC.


### PR DESCRIPTION
This includes the list of changes since the original paper. The section headings are similar to the issue logs at the end, so we may clean up at the end. Also, I didn't really install any tool to check this change (markdown and others). So please let me if this doesn't work. This fixes #10.