### PR TITLE
Pretty Latex math

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -14,6 +14,9 @@ on:
     - LICENSE.md
     - .gitignore
 
+env:
+  LANG: "en_US.UTF-8"
+
 jobs:
   build:
     name: "Update Editor's Copy"
@@ -57,3 +60,8 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: "*.txt"
+
+    - name: "Save XML"
+      uses: actions/upload-artifact@v2
+      with:
+        path: "*.xml"

--- a/.github/workflows/markdownlint.json
+++ b/.github/workflows/markdownlint.json
@@ -1,6 +1,8 @@
 {
   "default": true,
   "MD029": {"style": "ordered" },
+  "MD031": false,
+  "MD033": false,
   "MD034": false,
   "MD040": false,
   "MD041": false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.txt
 *.upload
 *~
+.markdownlintrc
 .refcache
 .tags
 .targets.mk

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@ ASCIITEX := $(shell which asciitex)
 SVGCHECK := $(shell which svgcheck)
 TEX2SVG := $(shell which tex2svg)
 
-$(info ${ASCIITEX})
-$(info ${SVGCHECK})
-$(info ${TEX2SVG})
-
 apt-update:
 	DEBIAN_FRONTEND=noninteractive apt-get update
 
@@ -35,6 +31,12 @@ asciitex: apt-update
 	cmake -S asciiTeX -B build -DDISABLE_TESTING=ON
 	cmake --build build
 	cmake --install build
+	-kramdown-rfc2629 -V
+	-xml2rfc -V
+	-npm -v
+	-tex2svg --version
+	-svgcheck -V
+	-asciitex -v
 else
 asciitex:
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,34 @@
+.PHONY: apt-update tex2svg-install asciitex-install svgcheck-install patch-toolchain
+
+latest:: apt-update tex2svg-install asciitex-install svgcheck-install patch-toolchain
+
+apt-update:
+	-DEBIAN_FRONTEND=noninteractive apt-get update
+	-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sudo locales cmake build-essential npm
+
+svgcheck-install:
+	@hash svgcheck 2>/dev/null || pip3 install svgcheck
+
+tex2svg-install:
+	@hash tex2svg 2>/dev/null || npm install -g mathjax-node-cli
+
+asciitex-install:
+	sudo locale-gen en_US.UTF-8
+	sudo update-locale LANG=en_US.UTF-8
+	-git clone --recursive --depth=1 https://github.com/larseggert/asciiTeX.git
+	cmake -S asciiTeX -B build -DDISABLE_TESTING=ON
+	cmake --build build
+	cmake --install build
+
+patch-toolchain:
+	-sed -e 's/--font STIX/--font STIX --speech=false/' -i'' /var/lib/gems/2.7.0/gems/kramdown-rfc2629-1.3.17/lib/kramdown-rfc2629.rb
+# 	-kramdown-rfc2629 -V
+# 	-xml2rfc -V
+# 	-npm -v
+# 	-tex2svg --version
+# 	-svgcheck -V
+# 	-asciitex -v
+
 LIBDIR := lib
 include $(LIBDIR)/main.mk
 
@@ -10,8 +41,11 @@ else
 	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
 
+.SECONDARY: draft-eggert-tcpm-rfc8312bis.xml
+
 CFLAGS=-Wall -Wextra -Weverything
 tablecode: tablecode.c
 
 clean::
-	rm tablecode 2> /dev/null || true
+	-rm tablecode 2> /dev/null
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: apt-update tex2svg asciitex svgcheck
+.PHONY: apt-update tex2svg asciitex svgcheck versions
 
-latest:: tex2svg asciitex svgcheck
+latest:: tex2svg asciitex svgcheck versions
 
 ASCIITEX := $(shell which asciitex)
 SVGCHECK := $(shell which svgcheck)
@@ -31,15 +31,17 @@ asciitex: apt-update
 	cmake -S asciiTeX -B build -DDISABLE_TESTING=ON
 	cmake --build build
 	cmake --install build
+else
+asciitex:
+endif
+
+versions:
 	-kramdown-rfc2629 -V
 	-xml2rfc -V
 	-npm -v
 	-tex2svg --version
 	-svgcheck -V
 	-asciitex -v
-else
-asciitex:
-endif
 
 LIBDIR := lib
 include $(LIBDIR)/main.mk

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -317,7 +317,12 @@ C:
 : constant that determines the aggressiveness of CUBIC in competing
   with other congestion control algorithms in high BDP networks. Please
   see {{discussion}} for more explanation on how it is set. The unit for
-  C is segment / (second)^3
+  C is
+
+~~~ math
+\frac{segment}{second^3}
+~~~
+{: artwork-align="center" }
 
 ### Variables of interest
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -122,8 +122,8 @@ informative:
 
 CUBIC is an extension to the current TCP standards. It differs from
 the current TCP standards only in the congestion control algorithm on
-the sender side. In particular, it uses a cubic function instead of
-a linear window increase function of the current TCP standards to
+the sender side. In particular, it uses a cubic function instead of a
+linear window increase function of the current TCP standards to
 improve scalability and stability under fast and long-distance
 networks. CUBIC and its predecessor algorithm have been adopted as
 defaults by Linux and have been used for many years. This document
@@ -136,49 +136,49 @@ CUBIC to conform to the current Linux version.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the [TCPM working group mailing
-list](mailto:tcpm@ietf.org), which is archived at
+Discussion of this draft takes place on the [TCPM working group
+mailing list](mailto:tcpm@ietf.org), which is archived at
 [](https://mailarchive.ietf.org/arch/browse/tcpm/).
 
 Working Group information can be found at
-[](https://datatracker.ietf.org/wg/tcpm/); source code and issues list for this
-draft can be found at [](https://github.com/NTAP/rfc8312bis).
+[](https://datatracker.ietf.org/wg/tcpm/); source code and issues list
+for this draft can be found at [](https://github.com/NTAP/rfc8312bis).
 
 --- middle
 
 # Introduction
 
 The low utilization problem of TCP in fast long-distance networks is
-well documented in {{?K03}} and {{?RFC3649}}. This problem arises from a
-slow increase of the congestion window following a congestion event
+well documented in {{?K03}} and {{?RFC3649}}. This problem arises from
+a slow increase of the congestion window following a congestion event
 in a network with a large bandwidth-delay product (BDP). {{HKLRX06}}
 indicates that this problem is frequently observed even in the range
 of congestion window sizes over several hundreds of packets. This
 problem is equally applicable to all Reno-style TCP standards and
 their variants, including TCP-Reno {{!RFC5681}}, TCP-NewReno
-{{!RFC6582}}{{!RFC6675}}, SCTP {{?RFC4960}}, and TFRC {{!RFC5348}}, which
-use the same linear increase function for window growth, which we refer to
-collectively as "Standard TCP" below.
+{{!RFC6582}}{{!RFC6675}}, SCTP {{?RFC4960}}, and TFRC {{!RFC5348}},
+which use the same linear increase function for window growth, which
+we refer to collectively as "Standard TCP" below.
 
 CUBIC, originally proposed in {{?HRX08}}, is a modification to the
 congestion control algorithm of Standard TCP to remedy this problem.
 This document describes the most recent specification of CUBIC.
 Specifically, CUBIC uses a cubic function instead of a linear window
-increase function of Standard TCP to improve scalability and
-stability under fast and long-distance networks.
+increase function of Standard TCP to improve scalability and stability
+under fast and long-distance networks.
 
 Binary Increase Congestion Control (BIC-TCP) {{XHR04}}, a predecessor
-of CUBIC, was selected as the default TCP congestion control
-algorithm by Linux in the year 2005 and has been used for several
-years by the Internet community at large. CUBIC uses a similar
-window increase function as BIC-TCP and is designed to be less
-aggressive and fairer to Standard TCP in bandwidth usage than BIC-TCP
-while maintaining the strengths of BIC-TCP such as stability, window
-scalability, and RTT fairness. CUBIC has already replaced BIC-TCP as
-the default TCP congestion control algorithm in Linux and has been
-deployed globally by Linux. Through extensive testing in various
-Internet scenarios, we believe that CUBIC is safe for testing and
-deployment in the global Internet.
+of CUBIC, was selected as the default TCP congestion control algorithm
+by Linux in the year 2005 and has been used for several years by the
+Internet community at large. CUBIC uses a similar window increase
+function as BIC-TCP and is designed to be less aggressive and fairer
+to Standard TCP in bandwidth usage than BIC-TCP while maintaining the
+strengths of BIC-TCP such as stability, window scalability, and RTT
+fairness. CUBIC has already replaced BIC-TCP as the default TCP
+congestion control algorithm in Linux and has been deployed globally
+by Linux. Through extensive testing in various Internet scenarios, we
+believe that CUBIC is safe for testing and deployment in the global
+Internet.
 
 In the following sections, we first briefly explain the design
 principles of CUBIC, then provide the exact specification of CUBIC,
@@ -214,32 +214,33 @@ decrease factor in order to balance between the scalability and
 convergence speed.
 
 Principle 1: For better network utilization and stability, CUBIC
-{{?HRX08}} uses a cubic window increase function in terms of the elapsed
-time from the last congestion event. While most alternative
+{{?HRX08}} uses a cubic window increase function in terms of the
+elapsed time from the last congestion event. While most alternative
 congestion control algorithms to Standard TCP increase the congestion
 window using convex functions, CUBIC uses both the concave and convex
 profiles of a cubic function for window growth. After a window
 reduction in response to a congestion event is detected by duplicate
 ACKs or Explicit Congestion Notification-Echo (ECN-Echo) ACKs
 {{!RFC3168}}, CUBIC registers the congestion window size where it got
-the congestion event as W_max and performs a multiplicative decrease
-of congestion window. After it enters into congestion avoidance, it
-starts to increase the congestion window using the concave profile of
-the cubic function. The cubic function is set to have its plateau at
-W_max so that the concave window increase continues until the window
-size becomes W_max. After that, the cubic function turns into a
-convex profile and the convex window increase begins. This style of
-window adjustment (concave and then convex) improves the algorithm
-stability while maintaining high network utilization {{?CEHRX07}}. This
-is because the window size remains almost constant, forming a plateau
-around W_max where network utilization is deemed highest. Under
-steady state, most window size samples of CUBIC are close to W_max,
-thus promoting high network utilization and stability. Note that
-those congestion control algorithms using only convex functions to
-increase the congestion window size have the maximum increments
-around W_max, and thus introduce a large number of packet bursts
-around the saturation point of the network, likely causing frequent
-global loss synchronizations.
+the congestion event as W<sub>max</sub> and performs a multiplicative
+decrease of congestion window. After it enters into congestion
+avoidance, it starts to increase the congestion window using the
+concave profile of the cubic function. The cubic function is set to
+have its plateau at W<sub>max</sub> so that the concave window
+increase continues until the window size becomes W<sub>max</sub>.
+After that, the cubic function turns into a convex profile and the
+convex window increase begins. This style of window adjustment
+(concave and then convex) improves the algorithm stability while
+maintaining high network utilization {{?CEHRX07}}. This is because the
+window size remains almost constant, forming a plateau around
+W<sub>max</sub> where network utilization is deemed highest. Under
+steady state, most window size samples of CUBIC are close to
+W<sub>max</sub>, thus promoting high network utilization and
+stability. Note that those congestion control algorithms using only
+convex functions to increase the congestion window size have the
+maximum increments around W<sub>max</sub>, and thus introduce a large
+number of packet bursts around the saturation point of the network,
+likely causing frequent global loss synchronizations.
 
 Principle 2: CUBIC promotes per-flow fairness to Standard TCP. Note
 that Standard TCP performs well under short RTT and small bandwidth
@@ -247,57 +248,55 @@ that Standard TCP performs well under short RTT and small bandwidth
 networks with long RTTs and large bandwidth (or large BDP). An
 alternative congestion control algorithm to Standard TCP designed to
 be friendly to Standard TCP on a per-flow basis must operate to
-increase its congestion window less aggressively in small BDP
-networks than in large BDP networks. The aggressiveness of CUBIC
-mainly depends on the maximum window size before a window reduction,
-which is smaller in small BDP networks than in large BDP networks.
-Thus, CUBIC increases its congestion window less aggressively in
-small BDP networks than in large BDP networks. Furthermore, in cases
-when the cubic function of CUBIC increases its congestion window less
+increase its congestion window less aggressively in small BDP networks
+than in large BDP networks. The aggressiveness of CUBIC mainly depends
+on the maximum window size before a window reduction, which is smaller
+in small BDP networks than in large BDP networks. Thus, CUBIC
+increases its congestion window less aggressively in small BDP
+networks than in large BDP networks. Furthermore, in cases when the
+cubic function of CUBIC increases its congestion window less
 aggressively than Standard TCP, CUBIC simply follows the window size
 of Standard TCP to ensure that CUBIC achieves at least the same
-throughput as Standard TCP in small BDP networks. We call this
-region where CUBIC behaves like Standard TCP, the "TCP-friendly
-region".
+throughput as Standard TCP in small BDP networks. We call this region
+where CUBIC behaves like Standard TCP, the "TCP-friendly region".
 
-Principle 3: Two CUBIC flows with different RTTs have their
-throughput ratio linearly proportional to the inverse of their RTT
-ratio, where the throughput of a flow is approximately the size of
-its congestion window divided by its RTT. Specifically, CUBIC
-maintains a window increase rate independent of RTTs outside of the
-TCP-friendly region, and thus flows with different RTTs have similar
-congestion window sizes under steady state when they operate outside
-the TCP-friendly region. This notion of a linear throughput ratio is
-similar to that of Standard TCP under high statistical multiplexing
-environments where packet losses are independent of individual flow
-rates. However, under low statistical multiplexing environments, the
-throughput ratio of Standard TCP flows with different RTTs is
-quadratically proportional to the inverse of their RTT ratio {{XHR04}}.
-CUBIC always ensures the linear throughput ratio independent of the
-levels of statistical multiplexing. This is an improvement over
-Standard TCP. While there is no consensus on particular throughput
-ratios of different RTT flows, we believe that under wired Internet,
-use of a linear throughput ratio seems more reasonable than equal
-throughputs (i.e., the same throughput for flows with different RTTs)
-or a higher-order throughput ratio (e.g., a quadratical throughput
-ratio of Standard TCP under low statistical multiplexing
-environments).
+Principle 3: Two CUBIC flows with different RTTs have their throughput
+ratio linearly proportional to the inverse of their RTT ratio, where
+the throughput of a flow is approximately the size of its congestion
+window divided by its RTT. Specifically, CUBIC maintains a window
+increase rate independent of RTTs outside of the TCP-friendly region,
+and thus flows with different RTTs have similar congestion window
+sizes under steady state when they operate outside the TCP-friendly
+region. This notion of a linear throughput ratio is similar to that of
+Standard TCP under high statistical multiplexing environments where
+packet losses are independent of individual flow rates. However, under
+low statistical multiplexing environments, the throughput ratio of
+Standard TCP flows with different RTTs is quadratically proportional
+to the inverse of their RTT ratio {{XHR04}}. CUBIC always ensures the
+linear throughput ratio independent of the levels of statistical
+multiplexing. This is an improvement over Standard TCP. While there is
+no consensus on particular throughput ratios of different RTT flows,
+we believe that under wired Internet, use of a linear throughput ratio
+seems more reasonable than equal throughputs (i.e., the same
+throughput for flows with different RTTs) or a higher-order throughput
+ratio (e.g., a quadratical throughput ratio of Standard TCP under low
+statistical multiplexing environments).
 
-Principle 4: To balance between the scalability and convergence
-speed, CUBIC sets the multiplicative window decrease factor to 0.7
-while Standard TCP uses 0.5. While this improves the scalability of
-CUBIC, a side effect of this decision is slower convergence,
-especially under low statistical multiplexing environments. This
-design choice is following the observation that the author of
-HighSpeed TCP (HSTCP) {{?RFC3649}} has made along with other researchers
-(e.g., {{GV02}}): the current Internet becomes more asynchronous with
-less frequent loss synchronizations with high statistical
-multiplexing. Under this environment, even strict Multiplicative-Increase
-Multiplicative-Decrease (MIMD) can converge. CUBIC flows
-with the same RTT always converge to the same throughput independent
-of statistical multiplexing, thus achieving intra-algorithm fairness.
-We also find that under the environments with sufficient statistical
-multiplexing, the convergence speed of CUBIC flows is reasonable.
+Principle 4: To balance between the scalability and convergence speed,
+CUBIC sets the multiplicative window decrease factor to 0.7 while
+Standard TCP uses 0.5. While this improves the scalability of CUBIC, a
+side effect of this decision is slower convergence, especially under
+low statistical multiplexing environments. This design choice is
+following the observation that the author of HighSpeed TCP (HSTCP)
+{{?RFC3649}} has made along with other researchers (e.g., {{GV02}}):
+the current Internet becomes more asynchronous with less frequent loss
+synchronizations with high statistical multiplexing. Under this
+environment, even strict Multiplicative-Increase
+Multiplicative-Decrease (MIMD) can converge. CUBIC flows with the same
+RTT always converge to the same throughput independent of statistical
+multiplexing, thus achieving intra-algorithm fairness. We also find
+that under the environments with sufficient statistical multiplexing,
+the convergence speed of CUBIC flows is reasonable.
 
 # CUBIC Congestion Control
 
@@ -311,13 +310,13 @@ maximum segment size (MSS), and the unit of all times is seconds.
 
 ### Constants of interest
 
-beta_cubic:
+{{{β}{}}}<sub>cubic</sub>:
 : CUBIC multiplication decrease factor as described in {{mult-dec}}
 
 C:
 : constant that determines the aggressiveness of CUBIC in competing
-  with other congestion control algorithms in high BDP networks. Please see
-  {{discussion}} for more explanation on how it is set. The unit for
+  with other congestion control algorithms in high BDP networks. Please
+  see {{discussion}} for more explanation on how it is set. The unit for
   C is segment / (second)^3
 
 ### Variables of interest
@@ -325,7 +324,8 @@ C:
 Variables required to implement CUBIC are described in this section.
 
 RTT:
-: Smoothed round-trip time in seconds calculated as described in {{!RFC6298}}
+: Smoothed round-trip time in seconds calculated as described in
+  {{!RFC6298}}
 
 cwnd:
 : Current congestion window in segments
@@ -333,13 +333,13 @@ cwnd:
 ssthresh:
 : Current slow start threshold in segments
 
-W_max:
+W<sub>max</sub>:
 : Size of the cwnd in segments just before the cwnd is reduced in the
   last congestion event
 
 K:
 : The time period in seconds it takes to increase the current congestion
-  window size to W_max
+  window size to W<sub>max</sub>
 
 current_time
 : Current time of the system in seconds
@@ -347,35 +347,36 @@ current_time
 epoch_start:
 : The time in seconds at which the current congestion avoidance stage starts
 
-W_cubic(t):
+W<sub>cubic</sub>(t):
 : Target value of the congestion window in segments at time t in seconds
   based on the cubic increase function as described in {{win-inc}}
 
 target:
 : Target value of congestion window in segments after the next RTT,
-  that is, W_cubic(t+RTT) as described in {{win-inc}}
+  that is, W<sub>cubic</sub>(t + RTT) as described in {{win-inc}}
 
-W_est:
-: An estimate for the congestion window in segments in the TCP-friendly
-  region, that is, an estimate for the congestion window using the AIMD
-  approach similar to TCP-NewReno congestion controller
+W<sub>est</sub>:
+: An estimate for the congestion window in segments in the
+  TCP-friendly region, that is, an estimate for the congestion window
+  using the AIMD approach similar to TCP-NewReno congestion controller
 
 ## Window Increase Function {#win-inc}
 
 CUBIC maintains the acknowledgment (ACK) clocking of Standard TCP by
 increasing the congestion window only at the reception of an ACK. It
 does not make any change to the fast recovery and retransmit of TCP,
-such as TCP-NewReno {{!RFC6582}}{{!RFC6675}}. During congestion avoidance
-after a congestion event where a packet loss is detected by duplicate
-ACKs or a network congestion is detected by ACKs with ECN-Echo flags
-{{!RFC3168}}, CUBIC changes the window increase function of Standard
-TCP.
+such as TCP-NewReno {{!RFC6582}}{{!RFC6675}}. During congestion
+avoidance after a congestion event where a packet loss is detected by
+duplicate ACKs or a network congestion is detected by ACKs with
+ECN-Echo flags {{!RFC3168}}, CUBIC changes the window increase
+function of Standard TCP.
 
 CUBIC uses the following window increase function:
 
+~~~ math
+\mathrm{W_{cubic}}(t) = C * (t - K)^3 + W_{max}
 ~~~
-    W_cubic(t) = C * (t - K)^3 + W_max                (Eq. 1)
-~~~
+{: #eq1 artwork-align="center" }
 
 where t is the elapsed time in seconds from the beginning of the
 current congestion avoidance stage, that is, t = (current_time -
@@ -385,136 +386,175 @@ above function takes to increase the current window size to W_max
 if there are no further congestion events and is calculated using
 the following equation:
 
+~~~ math
+K = \sqrt[3]{\frac{W_{max} - cwnd}{C}}
 ~~~
-    K = cubic_root((W_max - cwnd) / C)                (Eq. 2)
-~~~
+{: #eq2 artwork-align="center" }
 
 where cwnd is the congestion window at the beginning of the current
 congestion avoidance stage. The cwnd is calculated as described in
 {{mult-dec}} when a congestion event is detected, although
 implementations can further adjust the cwnd based on other fast
 recovery mechanisms. In special cases, if the cwnd is greater than
-W_max, K is set to 0.
+W<sub>max</sub>, K is set to 0.
 
 Upon receiving an ACK during congestion avoidance, CUBIC computes the
-target congestion window size after the next RTT using Eq. 1 as
-follows, where RTT is the smoothed round-trip time. The lower and upper
-bounds below ensure that CUBIC's congestion window increase rate is
-non-decreasing and is less than the increase rate of slow start.
+target congestion window size after the next RTT using {{eq1}} as
+follows, where RTT is the smoothed round-trip time. The lower and
+upper bounds below ensure that CUBIC's congestion window increase rate
+is non-decreasing and is less than the increase rate of slow start.
 
+~~~ math
+target = \left\{
+\begin{array}{ll}
+cwnd                          &
+\text{if } \mathrm{W_{cubic}}(t + RTT) < cwnd \\
+1.5 * cwnd                    &
+\text{if } \mathrm{W_{cubic}}(t + RTT) > 1.5 * cwnd \\
+\mathrm{W_{cubic}}(t + RTT)   &
+\text{otherwise} \\
+\end{array} \right.
 ~~~
-    target = W_cubic(t + RTT)         // cwnd after an RTT
-    if (target < cwnd) {              // lower bound
-        target = cwnd
-    } else if (target > 1.5 * cwnd) { // upper bound
-        target = 1.5 * cwnd
-    }
-~~~
+{: artwork-align="center" }
 
 Depending on the value of the current congestion window size cwnd,
 CUBIC runs in three different modes.
 
-1. The TCP-friendly region, which ensures that CUBIC achieves at
-   least the same throughput as Standard TCP.
+1. The TCP-friendly region, which ensures that CUBIC achieves at least
+   the same throughput as Standard TCP.
 
-2. The concave region, if CUBIC is not in the TCP-friendly region
-   and cwnd is less than W_max.
+2. The concave region, if CUBIC is not in the TCP-friendly region and
+   cwnd is less than W<sub>max</sub>.
 
 3. The convex region, if CUBIC is not in the TCP-friendly region and
-   cwnd is greater than W_max.
+   cwnd is greater than W<sub>max</sub>.
 
 Below, we describe the exact actions taken by CUBIC in each region.
 
 ## TCP-Friendly Region
 
 Standard TCP performs well in certain types of networks, for example,
-under short RTT and small bandwidth (or small BDP) networks. In
-these networks, we use the TCP-friendly region to ensure that CUBIC
-achieves at least the same throughput as Standard TCP.
+under short RTT and small bandwidth (or small BDP) networks. In these
+networks, we use the TCP-friendly region to ensure that CUBIC achieves
+at least the same throughput as Standard TCP.
 
 The TCP-friendly region is designed according to the analysis
 described in {{FHP00}}. The analysis studies the performance of an
-Additive Increase and Multiplicative Decrease (AIMD) algorithm with
-an additive factor of alpha_aimd (segments per RTT) and a
-multiplicative factor of beta_aimd, denoted by AIMD(alpha_aimd,
-beta_aimd). Specifically, the average congestion window size of
-AIMD(alpha_aimd, beta_aimd) can be calculated using Eq. 3. The
-analysis shows that AIMD(alpha_aimd, beta_aimd) with
-alpha_aimd=3*(1-beta_aimd)/(1+beta_aimd) achieves the same average
-window size as Standard TCP that uses AIMD(1, 0.5).
+Additive Increase and Multiplicative Decrease (AIMD) algorithm with an
+additive factor of {{{α}{}}}<sub>aimd</sub> (segments per RTT) and a
+multiplicative factor of {{{β}{}}}<sub>aimd</sub>, denoted by
+AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>).
+Specifically, the average congestion window size of
+AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>) can be
+calculated using {{eq3}}. The analysis shows that
+AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>) with
 
+~~~ math
+α_{aimd} = 3 * \frac{1 - β_{cubic}}{1 + β_{cubic}}
 ~~~
-    AVG_W_aimd = [alpha_aimd * (1 + beta_aimd) /
-                  (2 * (1 - beta_aimd) * p)]^0.5      (Eq. 3)
-~~~
+{: artwork-align="center" }
 
-Based on the above analysis, CUBIC uses Eq. 4 to estimate the window
-size W_est of AIMD(alpha_aimd, beta_aimd) with
-alpha_aimd=3*(1-beta_cubic)/(1+beta_cubic) and beta_aimd=beta_cubic,
+achieves the same average window size as Standard TCP that uses AIMD(1, 0.5).
+
+~~~ math
+\mathrm{AIMD}(α_{aimd}, β_{aimd}) =
+    \sqrt{\frac{α_{aimd} * (1 + β_{aimd})}{2 * (1 - β_{aimd}) * p}}
+~~~
+{: #eq3 artwork-align="center" }
+
+Based on the above analysis, CUBIC uses {{eq4}} to estimate the window
+size W<sub>est</sub> of AIMD({{{α}{}}}<sub>aimd</sub>,
+{{{β}{}}}<sub>aimd</sub>) with
+
+~~~ math
+\begin{array}{l}
+α_{aimd} = 3 * \frac{1 - β_{cubic}}{1 + β_{cubic}} \\
+β_{aimd} = β_{cubic} \\
+\end{array}
+~~~
+{: artwork-align="center" }
+
 which achieves the same average window size as Standard TCP. When
 receiving an ACK in congestion avoidance (cwnd could be greater than
-or less than W_max), CUBIC checks whether W_cubic(t) is less than
-W_est. If so, CUBIC is in the TCP-friendly region and cwnd SHOULD
-be set to W_est at each reception of an ACK.
+or less than W<sub>max</sub>), CUBIC checks whether
+W<sub>cubic</sub>(t) is less than W<sub>est</sub>. If so, CUBIC is in
+the TCP-friendly region and cwnd SHOULD be set to W<sub>est</sub> at
+each reception of an ACK.
 
-W_est is set equal to cwnd at the start of the congestion avoidance
-stage. After that, on every ACK, W_est is updated using Eq. 4.
+W<sub>est</sub> is set equal to cwnd at the start of the congestion
+avoidance stage. After that, on every ACK, W<sub>est</sub> is updated
+using {{eq4}}.
 
+~~~ math
+W_{est} = W_{est} + α_{aimd} * \frac{segments_{acked}}{cwnd}
 ~~~
-    W_est = W_est + alpha_aimd * (segments_acked / cwnd) (Eq. 4)
-~~~
+{: #eq4 artwork-align="center" }
 
-Note that once W_est reaches W_max, that is, W_est >= W_max,
-alpha_aimd SHOULD be set to 1 to achieve the same congestion
-window size as standard TCP that uses AIMD.
+Note that once W<sub>est</sub> reaches W<sub>max</sub>, that is,
+W<sub>est</sub> >= W<sub>max</sub>, {{{α}{}}}<sub>aimd</sub> SHOULD be
+set to 1 to achieve the same congestion window size as standard TCP
+that uses AIMD.
 
 ## Concave Region
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is less than W_max, then CUBIC is in the
-concave region. In this region, cwnd MUST be incremented by
-(target - cwnd)/cwnd for each received ACK, where target is
-calculated as described in {{win-inc}}.
+TCP-friendly region and cwnd is less than W<sub>max</sub>, then CUBIC
+is in the concave region. In this region, cwnd MUST be incremented by
+
+~~~ math
+\frac{target - cwnd}{cwnd}
+~~~
+{: artwork-align="center" }
+
+for each received ACK, where target is calculated as described in
+{{win-inc}}.
 
 ## Convex Region
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is larger than or equal to W_max, then
-CUBIC is in the convex region. The convex region indicates that the
-network conditions might have been perturbed since the last
-congestion event, possibly implying more available bandwidth after
-some flow departures. Since the Internet is highly asynchronous,
-some amount of perturbation is always possible without causing a
-major change in available bandwidth. In this region, CUBIC is being
-very careful by very slowly increasing its window size. The convex
-profile ensures that the window increases very slowly at the
-beginning and gradually increases its increase rate. We also call
-this region the "maximum probing phase" since CUBIC is searching for
-a new W_max. In this region, cwnd MUST be incremented by
-(target - cwnd)/cwnd for each received ACK, where target is
-calculated as described in {{win-inc}}.
+TCP-friendly region and cwnd is larger than or equal to
+W<sub>max</sub>, then CUBIC is in the convex region. The convex region
+indicates that the network conditions might have been perturbed since
+the last congestion event, possibly implying more available bandwidth
+after some flow departures. Since the Internet is highly asynchronous,
+some amount of perturbation is always possible without causing a major
+change in available bandwidth. In this region, CUBIC is being very
+careful by very slowly increasing its window size. The convex profile
+ensures that the window increases very slowly at the beginning and
+gradually increases its increase rate. We also call this region the
+"maximum probing phase" since CUBIC is searching for a new
+W<sub>max</sub>. In this region, cwnd MUST be incremented by (target -
+cwnd)/cwnd for each received ACK, where target is calculated as
+described in {{win-inc}}.
 
 ## Multiplicative Decrease {#mult-dec}
 
 When a packet loss is detected by duplicate ACKs or a network
 congestion is detected by receiving packets marked with ECN-Echo (ECE),
-CUBIC updates its W_max and reduces its cwnd and ssthresh immediately
+CUBIC updates its W<sub>max</sub> and reduces its cwnd and ssthresh immediately
 as below. For both packet loss and congestion detection through ECN,
 the sender MAY employ a fast recovery algorithm to gradually adjust the
-congestion window to its new reduced value. Parameter beta_cubic
+congestion window to its new reduced value. Parameter {{{β}{}}}<sub>cubic</sub>
 SHOULD be set to 0.7.
 
+~~~ math
+\begin{array}{ll}
+ssthresh = cwnd * β_{cubic} &
+\text{// new slow-start threshold} \\
+ssthresh = \mathrm{max}(ssthresh, 2) &
+\text{// threshold is at least 2 MSS} \\
+cwnd = ssthresh &
+\text{// window reduction} \\
+\end{array}
 ~~~
-    ssthresh = cwnd * beta_cubic // new slow-start threshold
-    ssthresh = max(ssthresh, 2)  // threshold is at least 2 MSS
-    cwnd = ssthresh              // window reduction
-~~~
+{: artwork-align="center" }
 
-A side effect of setting beta_cubic to a value bigger than 0.5 is
-slower convergence. We believe that while a more adaptive setting of
-beta_cubic could result in faster convergence, it will make the
-analysis of CUBIC much harder. This adaptive adjustment of
-beta_cubic is an item for the next version of CUBIC.
+A side effect of setting {{{β}{}}}<sub>cubic</sub> to a value bigger
+than 0.5 is slower convergence. We believe that while a more adaptive
+setting of {{{β}{}}}<sub>cubic</sub> could result in faster
+convergence, it will make the analysis of CUBIC much harder. This
+adaptive adjustment of {{{β}{}}}<sub>cubic</sub> is an item for the
+next version of CUBIC.
 
 ## Fast Convergence
 
@@ -529,13 +569,16 @@ SHOULD be implemented.
 With fast convergence, when a congestion event occurs, we update W_max
 as follows before the window reduction as described in Section 4.5.
 
+~~~ math
+W_{max} = \left\{
+\begin{array}{ll}
+W_{max} * \frac{1 + β_{cubic}}{2}
+& \text{if } cwnd < W_{max}, \text{further reduce } W_{max} \\
+cwnd
+&\text{otherwise, remember cwnd before reduction} \\
+\end{array} \right.
 ~~~
-      if (cwnd < W_max){                        // should we make room for others
-          W_max = W_max*(1.0+beta_cubic)/2.0;   // further reduce W_max
-      } else {
-          W_max = cwnd                          // remember cwnd before reduction
-      }
-~~~
+{: artwork-align="center" }
 
 At a congestion event, if the current cwnd is less than W_max, this
 indicates that the saturation point experienced by this flow is getting
@@ -547,15 +590,15 @@ the plateau earlier.  This allows more time for the new flow to catch
 up to its congestion window size.
 
 The fast convergence is designed for network environments with
-multiple CUBIC flows. In network environments with only a single
-CUBIC flow and without any other traffic, the fast convergence SHOULD
-be disabled.
+multiple CUBIC flows. In network environments with only a single CUBIC
+flow and without any other traffic, the fast convergence SHOULD be
+disabled.
 
 ## Timeout
 
 In case of timeout, CUBIC follows Standard TCP to reduce cwnd
-{{!RFC5681}}, but sets ssthresh using beta_cubic (same as in
-{{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
+{{!RFC5681}}, but sets ssthresh using {{{β}{}}}<sub>cubic</sub> (same
+as in {{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
 
 During the first congestion avoidance after a timeout, CUBIC
 increases its congestion window size using Eq. 1, where t is the
@@ -588,6 +631,7 @@ value of the following variables before the congestion window reduction.
     prior_epoch_start = epoch_start
     prior_W_est = W_est
 ~~~
+{: artwork-align="center" }
 
 CUBIC MAY implement an algorithm to detect spurious retransmissions,
 such as DSACK {{?RFC3708}}, Forward RTO-Recovery {{?RFC5682}} or
@@ -616,17 +660,18 @@ continue to use the current and the most recent values of these variables.
 
 CUBIC MUST employ a slow-start algorithm, when the cwnd is no more
 than ssthresh. Among the slow-start algorithms, CUBIC MAY choose the
-standard TCP slow start {{!RFC5681}} in general networks, or the limited
-slow start {{?RFC3742}} or hybrid slow start {{HR08}} for fast and long-
-distance networks.
+standard TCP slow start {{!RFC5681}} in general networks, or the
+limited slow start {{?RFC3742}} or hybrid slow start {{HR08}} for fast
+and long- distance networks.
 
-In the case when CUBIC runs the hybrid slow start {{HR08}}, it may exit
-the first slow start without incurring any packet loss and thus W_max
-is undefined. In this special case, CUBIC switches to congestion
-avoidance and increases its congestion window size using Eq. 1, where
-t is the elapsed time since the beginning of the current congestion
-avoidance, K is set to 0, and W_max is set to the congestion window
-size at the beginning of the current congestion avoidance.
+In the case when CUBIC runs the hybrid slow start {{HR08}}, it may
+exit the first slow start without incurring any packet loss and thus
+W<sub>max</sub> is undefined. In this special case, CUBIC switches to
+congestion avoidance and increases its congestion window size using
+{{eq1}}, where t is the elapsed time since the beginning of the
+current congestion avoidance, K is set to 0, and W<sub>max</sub> is
+set to the congestion window size at the beginning of the current
+congestion avoidance.
 
 # Discussion {#discussion}
 
@@ -634,26 +679,26 @@ In this section, we further discuss the safety features of CUBIC
 following the guidelines specified in {{!RFC5033}}.
 
 With a deterministic loss model where the number of packets between
-two successive packet losses is always 1/p, CUBIC always operates
-with the concave window profile, which greatly simplifies the
-performance analysis of CUBIC. The average window size of CUBIC can
-be obtained by the following function:
+two successive packet losses is always 1/p, CUBIC always operates with
+the concave window profile, which greatly simplifies the performance
+analysis of CUBIC. The average window size of CUBIC can be obtained by
+the following function:
 
+~~~ math
+AVG\_W_{cubic} = \sqrt[4]{\frac{C * (3 + β_{cubic})}{4 * (1 - β_{cubic})}} * \frac{\sqrt[3]{RTT^4}}{\sqrt[3]{p^4}}
 ~~~
-    AVG_W_cubic = [C * (3 + beta_cubic) /
-                   (4 * (1 - beta_cubic))]^0.25 *
-                  (RTT^0.75) / (p^0.75)               (Eq. 5)
-~~~
+{: #eq5 artwork-align="center" }
 
-With beta_cubic set to 0.7, the above formula is reduced to:
+With {{{β}{}}}<sub>cubic</sub> set to 0.7, the above formula is reduced to:
 
+~~~ math
+AVG\_W_{cubic} = \sqrt[4]{\frac{C * 3.7}{1.2}} *
+                 \frac{\sqrt[3]{RTT^4}}{\sqrt[3]{p^4}}
 ~~~
-    AVG_W_cubic = (C * 3.7 / 1.2)^0.25 * (RTT^0.75) / (p^0.75)
-                                                      (Eq. 6)
-~~~
+{: #eq6 artwork-align="center" }
 
 We will determine the value of C in the following subsection using
-Eq. 6.
+{{eq6}}.
 
 ## Fairness to Standard TCP
 
@@ -668,10 +713,10 @@ Standard TCP performs well in the following two types of networks:
 2. networks with a short RTTs, but not necessarily a small BDP
 
 CUBIC is designed to behave very similarly to Standard TCP in the
-above two types of networks. The following two tables show the
-average window sizes of Standard TCP, HSTCP, and CUBIC. The average
-window sizes of Standard TCP and HSTCP are from {{?RFC3649}}. The
-average window size of CUBIC is calculated using Eq. 6 and the CUBIC
+above two types of networks. The following two tables show the average
+window sizes of Standard TCP, HSTCP, and CUBIC. The average window
+sizes of Standard TCP and HSTCP are from {{?RFC3649}}. The average
+window size of CUBIC is calculated using {{eq6}} and the CUBIC
 TCP-friendly region for three different values of C.
 
 | Loss Rate P | TCP | HSTCP | CUBIC (C=0.04) | CUBIC (C=0.4) | CUBIC (C=4) |
@@ -706,28 +751,29 @@ is in MSS-sized segments.
 
 Both tables show that CUBIC with any of these three C values is more
 friendly to TCP than HSTCP, especially in networks with a short RTT
-where TCP performs reasonably well. For example, in a network with
-RTT = 0.01 seconds and p=10^-6, TCP has an average window of 1200
-packets. If the packet size is 1500 bytes, then TCP can achieve an
-average rate of 1.44 Gbps. In this case, CUBIC with C=0.04 or C=0.4
-achieves exactly the same rate as Standard TCP, whereas HSTCP is
-about ten times more aggressive than Standard TCP.
+where TCP performs reasonably well. For example, in a network with RTT
+= 0.01 seconds and p=10^-6, TCP has an average window of 1200 packets.
+If the packet size is 1500 bytes, then TCP can achieve an average rate
+of 1.44 Gbps. In this case, CUBIC with C=0.04 or C=0.4 achieves
+exactly the same rate as Standard TCP, whereas HSTCP is about ten
+times more aggressive than Standard TCP.
 
 We can see that C determines the aggressiveness of CUBIC in competing
-with other congestion control algorithms for bandwidth. CUBIC is
-more friendly to Standard TCP, if the value of C is lower. However,
-we do not recommend setting C to a very low value like 0.04, since
-CUBIC with a low C cannot efficiently use the bandwidth in long RTT
-and high-bandwidth networks. Based on these observations and our
+with other congestion control algorithms for bandwidth. CUBIC is more
+friendly to Standard TCP, if the value of C is lower. However, we do
+not recommend setting C to a very low value like 0.04, since CUBIC
+with a low C cannot efficiently use the bandwidth in long RTT and
+high-bandwidth networks. Based on these observations and our
 experiments, we find C=0.4 gives a good balance between TCP-
 friendliness and aggressiveness of window increase. Therefore, C
-SHOULD be set to 0.4. With C set to 0.4, Eq. 6 is reduced to:
+SHOULD be set to 0.4. With C set to 0.4, {{eq6}} is reduced to:
 
+~~~ math
+AVG\_W_{cubic} = 1.054 * \frac{\sqrt[3]{RTT^4}}{\sqrt[3]{p^4}}
 ~~~
-    AVG_W_cubic = 1.054 * (RTT^0.75) / (p^0.75)       (Eq. 7)
-~~~
+{: #eq7 artwork-align="center" }
 
-Eq. 7 is then used in the next subsection to show the scalability of
+{{eq7}} is then used in the next subsection to show the scalability of
 CUBIC.
 
 ## Using Spare Capacity
@@ -774,16 +820,16 @@ algorithm. Because CUBIC is designed to be more aggressive (due to a
 faster window increase function and bigger multiplicative decrease
 factor) than Standard TCP in fast and long-distance networks, it can
 fill large drop-tail buffers more quickly than Standard TCP and
-increase the risk of a standing queue {{?RFC8511}}. In this case, proper
-queue sizing and management {{!RFC7567}} could be used to reduce the
-packet queuing delay.
+increase the risk of a standing queue {{?RFC8511}}. In this case,
+proper queue sizing and management {{!RFC7567}} could be used to
+reduce the packet queuing delay.
 
 ## Protection against Congestion Collapse
 
 With regard to the potential of causing congestion collapse, CUBIC
 behaves like Standard TCP since CUBIC modifies only the window
-adjustment algorithm of TCP. Thus, it does not modify the ACK
-clocking and Timeout behaviors of Standard TCP.
+adjustment algorithm of TCP. Thus, it does not modify the ACK clocking
+and Timeout behaviors of Standard TCP.
 
 ## Fairness within the Alternative Congestion Control Algorithm
 
@@ -800,11 +846,11 @@ This is not considered in the current CUBIC.
 ## Behavior for Application-Limited Flows
 
 CUBIC does not raise its congestion window size if the flow is
-currently limited by the application instead of the congestion
-window. In case of long periods when cwnd has not been updated due
-to the application rate limit, such as idle periods, t in Eq. 1 MUST
-NOT include these periods; otherwise, W_cubic(t) might be very high
-after restarting from these periods.
+currently limited by the application instead of the congestion window.
+In case of long periods when cwnd has not been updated due to the
+application rate limit, such as idle periods, t in {{eq1}} MUST NOT
+include these periods; otherwise, W<sub>cubic</sub>(t) might be very
+high after restarting from these periods.
 
 ## Responses to Sudden or Transient Events
 
@@ -814,16 +860,15 @@ event, CUBIC behaves the same as Standard TCP.
 ## Incremental Deployment
 
 CUBIC requires only the change of TCP senders, and it does not make
-any changes to TCP receivers. That is, a CUBIC sender works
-correctly with the Standard TCP receivers. In addition, CUBIC does
-not require any changes to the routers and does not require any
-assistance from the routers.
+any changes to TCP receivers. That is, a CUBIC sender works correctly
+with the Standard TCP receivers. In addition, CUBIC does not require
+any changes to the routers and does not require any assistance from
+the routers.
 
 # Security Considerations
 
-This proposal makes no changes to the underlying security of TCP.
-More information about TCP security concerns can be found in
-{{!RFC5681}}.
+This proposal makes no changes to the underlying security of TCP. More
+information about TCP security concerns can be found in {{!RFC5681}}.
 
 # IANA Considerations
 
@@ -857,7 +902,8 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
   [#14](https://github.com/NTAP/rfc8312bis/issues/14))
 - update W_est to use AIMD approach
   ([#20](https://github.com/NTAP/rfc8312bis/issues/20))
-- set alpha_aimd to 1 once W_est reaches W_max
+- set <!-- xml2rfc cannot handdle this here: {{{α}{}}} -->alpha<sub>aimd</sub>
+  to 1 once W<sub>est</sub> reaches W<sub>max</sub>
   ([#2](https://github.com/NTAP/rfc8312bis/issues/2))
 - add Vidhi as co-author ([#17](https://github.com/NTAP/rfc8312bis/issues/17))
 - note for fast recovery during cwnd decrease due to congestion event

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -317,7 +317,7 @@ C:
 : constant that determines the aggressiveness of CUBIC in competing
   with other congestion control algorithms in high BDP networks. Please
   see {{discussion}} for more explanation on how it is set. The unit for
--  C is segment / (second)^3
+  C is segment / (second)^3
 
 <!-- this does not work?
 ~~~ math

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -618,7 +618,7 @@ In case of timeout, CUBIC follows Standard TCP to reduce cwnd
 {{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
 
 During the first congestion avoidance after a timeout, CUBIC
-increases its congestion window size using Eq. 1, where t is the
+increases its congestion window size using {{eq1}}, where t is the
 elapsed time since the beginning of the current congestion avoidance,
 K is set to 0, and W_max is set to the congestion window size at the
 beginning of the current congestion avoidance. In addition, for the

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -317,12 +317,14 @@ C:
 : constant that determines the aggressiveness of CUBIC in competing
   with other congestion control algorithms in high BDP networks. Please
   see {{discussion}} for more explanation on how it is set. The unit for
-  C is
+-  C is segment / (second)^3
 
+<!-- this does not work?
 ~~~ math
 \frac{segment}{second^3}
 ~~~
 {: artwork-align="center" }
+-->
 
 ### Variables of interest
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -222,22 +222,22 @@ profiles of a cubic function for window growth. After a window
 reduction in response to a congestion event is detected by duplicate
 ACKs or Explicit Congestion Notification-Echo (ECN-Echo) ACKs
 {{!RFC3168}}, CUBIC registers the congestion window size where it got
-the congestion event as W<sub>max</sub> and performs a multiplicative decrease
+the congestion event as *W<sub>max</sub>* and performs a multiplicative decrease
 of congestion window. After it enters into congestion avoidance, it
 starts to increase the congestion window using the concave profile of
 the cubic function. The cubic function is set to have its plateau at
-W<sub>max</sub> so that the concave window increase continues until the window
-size becomes W<sub>max</sub>. After that, the cubic function turns into a
+*W<sub>max</sub>* so that the concave window increase continues until the window
+size becomes *W<sub>max</sub>*. After that, the cubic function turns into a
 convex profile and the convex window increase begins. This style of
 window adjustment (concave and then convex) improves the algorithm
 stability while maintaining high network utilization {{?CEHRX07}}. This
 is because the window size remains almost constant, forming a plateau
-around W<sub>max</sub> where network utilization is deemed highest. Under
-steady state, most window size samples of CUBIC are close to W<sub>max</sub>,
+around *W<sub>max</sub>* where network utilization is deemed highest. Under
+steady state, most window size samples of CUBIC are close to *W<sub>max</sub>*,
 thus promoting high network utilization and stability. Note that
 those congestion control algorithms using only convex functions to
 increase the congestion window size have the maximum increments
-around W<sub>max</sub>, and thus introduce a large number of packet bursts
+around *W<sub>max</sub>*, and thus introduce a large number of packet bursts
 around the saturation point of the network, likely causing frequent
 global loss synchronizations.
 
@@ -311,14 +311,14 @@ maximum segment size (MSS), and the unit of all times is seconds.
 
 ### Constants of interest
 
-{{{β}{}}}<sub>cubic</sub>:
+*{{{β}{}}}<sub>cubic</sub>*:
 CUBIC multiplication decrease factor as described in {{mult-dec}}
 
-C:
+*C*:
 constant that determines the aggressiveness of CUBIC in competing
 with other congestion control algorithms in high BDP networks. Please see
 {{discussion}} for more explanation on how it is set. The unit for
-C is
+*C* is
 
 ~~~ math
 \frac{segment}{second^3}
@@ -332,35 +332,35 @@ Variables required to implement CUBIC are described in this section.
 RTT:
 Smoothed round-trip time in seconds calculated as described in {{!RFC6298}}
 
-cwnd:
+*cwnd*:
 Current congestion window in segments
 
-ssthresh:
+*ssthresh*:
 Current slow start threshold in segments
 
-W<sub>max</sub>:
-Size of the cwnd in segments just before the cwnd is reduced in the
+*W<sub>max</sub>*:
+Size of *cwnd* in segments just before *cwnd* is reduced in the
 last congestion event
 
-K:
+*K*:
 The time period in seconds it takes to increase the current congestion
-window size to W<sub>max</sub>
+window size to *W<sub>max</sub>*
 
-current_time:
+*current_time*:
 Current time of the system in seconds
 
-epoch_start:
+*epoch_start*:
 The time in seconds at which the current congestion avoidance stage starts
 
 W<sub>cubic</sub>(t):
 Target value of the congestion window in segments at time t in seconds
 based on the cubic increase function as described in {{win-inc}}
 
-target:
+*target*:
 Target value of congestion window in segments after the next RTT,
 that is, W<sub>cubic</sub>(t + RTT) as described in {{win-inc}}
 
-W<sub>est</sub>:
+*W<sub>est</sub>*:
 An estimate for the congestion window in segments in the TCP-friendly
 region, that is, an estimate for the congestion window using the AIMD
 approach similar to TCP-NewReno congestion controller
@@ -391,9 +391,9 @@ t = current\_time - epoch\_start
 ~~~
 {: artwork-align="center" }
 
-where epoch_start is the time at which the current
-congestion avoidance stage starts. K is the time period that the
-above function takes to increase the current window size to W<sub>max</sub>
+where *epoch_start* is the time at which the current
+congestion avoidance stage starts. *K* is the time period that the
+above function takes to increase the current window size to *W<sub>max</sub>*
 if there are no further congestion events and is calculated using
 the following equation:
 
@@ -402,15 +402,15 @@ K = \sqrt[3]{\frac{W_{max} - cwnd}{C}}
 ~~~
 {: #eq2 artwork-align="center" }
 
-where cwnd is the congestion window at the beginning of the current
-congestion avoidance stage. The cwnd is calculated as described in
+where *cwnd* is the congestion window at the beginning of the current
+congestion avoidance stage. *cwnd* is calculated as described in
 {{mult-dec}} when a congestion event is detected, although
-implementations can further adjust the cwnd based on other fast
-recovery mechanisms. In special cases, if the cwnd is greater than
-W<sub>max</sub>, K is set to 0.
+implementations can further adjust *cwnd* based on other fast
+recovery mechanisms. In special cases, if *cwnd* is greater than
+*W<sub>max</sub>*, *K* is set to 0.
 
 Upon receiving an ACK during congestion avoidance, CUBIC computes the
-target congestion window size after the next RTT using {{eq1}} as
+*target* congestion window size after the next RTT using {{eq1}} as
 follows, where RTT is the smoothed round-trip time. The lower and upper
 bounds below ensure that CUBIC's congestion window increase rate is
 non-decreasing and is less than the increase rate of slow start.
@@ -428,17 +428,17 @@ cwnd                          &
 ~~~
 {: artwork-align="center" }
 
-Depending on the value of the current congestion window size cwnd,
+Depending on the value of the current congestion window size *cwnd*,
 CUBIC runs in three different modes.
 
 1. The TCP-friendly region, which ensures that CUBIC achieves at
    least the same throughput as Standard TCP.
 
 2. The concave region, if CUBIC is not in the TCP-friendly region
-   and cwnd is less than W<sub>max</sub>.
+   and *cwnd* is less than *W<sub>max</sub>*.
 
 3. The convex region, if CUBIC is not in the TCP-friendly region and
-   cwnd is greater than W<sub>max</sub>.
+   *cwnd* is greater than *W<sub>max</sub>*.
 
 Below, we describe the exact actions taken by CUBIC in each region.
 
@@ -452,13 +452,13 @@ achieves at least the same throughput as Standard TCP.
 The TCP-friendly region is designed according to the analysis
 described in {{FHP00}}. The analysis studies the performance of an
 Additive Increase and Multiplicative Decrease (AIMD) algorithm with
-an additive factor of {{{α}{}}}<sub>aimd</sub> (segments per RTT) and a
-multiplicative factor of {{{β}{}}}<sub>aimd</sub>, denoted by
-AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>).
+an additive factor of *{{{α}{}}}<sub>aimd</sub>* (segments per RTT) and a
+multiplicative factor of *{{{β}{}}}<sub>aimd</sub>*, denoted by
+AIMD(*{{{α}{}}}<sub>aimd</sub>*, *{{{β}{}}}<sub>aimd</sub>*).
 Specifically, the average congestion window size of
-AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>) can be
+AIMD(*{{{α}{}}}<sub>aimd</sub>*, *{{{β}{}}}<sub>aimd</sub>*) can be
 calculated using {{eq3}}. The analysis shows that
-AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>) with
+AIMD(*{{{α}{}}}<sub>aimd</sub>*, *{{{β}{}}}<sub>aimd</sub>*) with
 
 ~~~ math
 α_{aimd} = 3 * \frac{1 - β_{cubic}}{1 + β_{cubic}}
@@ -475,8 +475,8 @@ window size as Standard TCP that uses AIMD(1, 0.5).
 {: #eq3 artwork-align="center" }
 
 Based on the above analysis, CUBIC uses {{eq4}} to estimate the window
-size W<sub>est</sub> of AIMD({{{α}{}}}<sub>aimd</sub>,
-{{{β}{}}}<sub>aimd</sub>) with
+size *W<sub>est</sub>* of AIMD(*{{{α}{}}}<sub>aimd</sub>*,
+*{{{β}{}}}<sub>aimd</sub>*) with
 
 ~~~ math
 \begin{array}{l}
@@ -487,43 +487,43 @@ size W<sub>est</sub> of AIMD({{{α}{}}}<sub>aimd</sub>,
 {: artwork-align="center" }
 
 which achieves the same average window size as Standard TCP. When
-receiving an ACK in congestion avoidance (cwnd could be greater than
-or less than W<sub>max</sub>), CUBIC checks whether
-W<sub>cubic</sub>(t) is less than W<sub>est</sub>. If so, CUBIC is in
-the TCP-friendly region and cwnd SHOULD be set to W<sub>est</sub> at
+receiving an ACK in congestion avoidance (*cwnd* could be greater than
+or less than *W<sub>max</sub>*), CUBIC checks whether
+W<sub>cubic</sub>(t) is less than *W<sub>est</sub>*. If so, CUBIC is in
+the TCP-friendly region and *cwnd* SHOULD be set to *W<sub>est</sub>* at
 each reception of an ACK.
 
-W<sub>est</sub> is set equal to cwnd at the start of the congestion avoidance
-stage. After that, on every ACK, W<sub>est</sub> is updated using {{eq4}}.
+*W<sub>est</sub>* is set equal to *cwnd* at the start of the congestion avoidance
+stage. After that, on every ACK, *W<sub>est</sub>* is updated using {{eq4}}.
 
 ~~~ math
 W_{est} = W_{est} + α_{aimd} * \frac{segments\_acked}{cwnd}
 ~~~
 {: #eq4 artwork-align="center" }
 
-Note that once W<sub>est</sub> reaches W<sub>max</sub>, that is,
-W<sub>est</sub> >= W<sub>max</sub>, {{{α}{}}}<sub>aimd</sub> SHOULD be
+Note that once *W<sub>est</sub>* reaches *W<sub>max</sub>*, that is,
+*W<sub>est</sub>* >= *W<sub>max</sub>*, *{{{α}{}}}<sub>aimd</sub>* SHOULD be
 set to 1 to achieve the same congestion
 window size as standard TCP that uses AIMD.
 
 ## Concave Region
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is less than W<sub>max</sub>, then CUBIC is in the
-concave region. In this region, cwnd MUST be incremented by
+TCP-friendly region and *cwnd* is less than *W<sub>max</sub>*, then CUBIC is in the
+concave region. In this region, *cwnd* MUST be incremented by
 
 ~~~ math
 \frac{target - cwnd}{cwnd}
 ~~~
 {: artwork-align="center" }
 
-for each received ACK, where target is
+for each received ACK, where *target* is
 calculated as described in {{win-inc}}.
 
 ## Convex Region {#convex-region}
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is larger than or equal to W<sub>max</sub>, then
+TCP-friendly region and *cwnd* is larger than or equal to *W<sub>max</sub>*, then
 CUBIC is in the convex region. The convex region indicates that the
 network conditions might have been perturbed since the last
 congestion event, possibly implying more available bandwidth after
@@ -534,24 +534,24 @@ very careful by very slowly increasing its window size. The convex
 profile ensures that the window increases very slowly at the
 beginning and gradually increases its increase rate. We also call
 this region the "maximum probing phase" since CUBIC is searching for
-a new W<sub>max</sub>. In this region, cwnd MUST be incremented by
+a new *W<sub>max</sub>*. In this region, *cwnd* MUST be incremented by
 
 ~~~ math
 \frac{target - cwnd}{cwnd}
 ~~~
 {: artwork-align="center" }
 
-for each received ACK, where target is
+for each received ACK, where *target* is
 calculated as described in {{win-inc}}.
 
 ## Multiplicative Decrease {#mult-dec}
 
 When a packet loss is detected by duplicate ACKs or a network
 congestion is detected by receiving packets marked with ECN-Echo (ECE),
-CUBIC updates its W<sub>max</sub> and reduces its cwnd and ssthresh immediately
+CUBIC updates its *W<sub>max</sub>* and reduces its *cwnd* and *ssthresh* immediately
 as below. For both packet loss and congestion detection through ECN,
 the sender MAY employ a fast recovery algorithm to gradually adjust the
-congestion window to its new reduced value. Parameter {{{β}{}}}<sub>cubic</sub>
+congestion window to its new reduced value. Parameter *{{{β}{}}}<sub>cubic</sub>*
 SHOULD be set to 0.7.
 
 ~~~ math
@@ -566,12 +566,12 @@ cwnd = ssthresh &
 ~~~
 {: artwork-align="center" }
 
-A side effect of setting {{{β}{}}}<sub>cubic</sub> to a value bigger
+A side effect of setting *{{{β}{}}}<sub>cubic</sub>* to a value bigger
 than 0.5 is
 slower convergence. We believe that while a more adaptive setting of
-{{{β}{}}}<sub>cubic</sub> could result in faster convergence, it will make the
+*{{{β}{}}}<sub>cubic</sub>* could result in faster convergence, it will make the
 analysis of CUBIC much harder. This adaptive adjustment of
-{{{β}{}}}<sub>cubic</sub> is an item for the next version of CUBIC.
+*{{{β}{}}}<sub>cubic</sub>* is an item for the next version of CUBIC.
 
 ## Fast Convergence
 
@@ -583,7 +583,7 @@ bandwidth of the network. To speed up this bandwidth release by
 existing flows, the following mechanism called "fast convergence"
 SHOULD be implemented.
 
-With fast convergence, when a congestion event occurs, we update W<sub>max</sub>
+With fast convergence, when a congestion event occurs, we update *W<sub>max</sub>*
 as follows before the window reduction as described in {{convex-region}}.
 
 ~~~ math
@@ -597,12 +597,12 @@ cwnd
 ~~~
 {: artwork-align="center" }
 
-At a congestion event, if the current cwnd is less than W_max, this
+At a congestion event, if the current *cwnd* is less than *W<sub>max</sub>*, this
 indicates that the saturation point experienced by this flow is getting
 reduced because of the change in available bandwidth.  Then we allow
-this flow to release more bandwidth by reducing W_max further.  This
+this flow to release more bandwidth by reducing *W<sub>max</sub>* further.  This
 action effectively lengthens the time for this flow to increase its
-congestion window because the reduced W_max forces the flow to have
+congestion window because the reduced *W<sub>max</sub>* forces the flow to have
 the plateau earlier.  This allows more time for the new flow to catch
 up to its congestion window size.
 
@@ -613,14 +613,14 @@ be disabled.
 
 ## Timeout
 
-In case of timeout, CUBIC follows Standard TCP to reduce cwnd
-{{!RFC5681}}, but sets ssthresh using {{{β}{}}}<sub>cubic</sub> (same as in
+In case of timeout, CUBIC follows Standard TCP to reduce *cwnd*
+{{!RFC5681}}, but sets *ssthresh* using *{{{β}{}}}<sub>cubic</sub>* (same as in
 {{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
 
 During the first congestion avoidance after a timeout, CUBIC
 increases its congestion window size using {{eq1}}, where t is the
 elapsed time since the beginning of the current congestion avoidance,
-K is set to 0, and W_max is set to the congestion window size at the
+*K* is set to 0, and *W<sub>max</sub>* is set to the congestion window size at the
 beginning of the current congestion avoidance. In addition, for the
 tcp-friendliness region, W_est should be set to the congestion window
 size at the beginning of the current congestion avoidance.
@@ -637,7 +637,7 @@ events of congestion window reduction where spurious losses are
 incorrectly interpreted as congestion signals, thus degrading CUBIC's
 performance significantly.
 
-When there is a loss event, A CUBIC implementation SHOULD save the current
+When there is a loss event, a CUBIC implementation SHOULD save the current
 value of the following variables before the congestion window reduction.
 
 ~~~ math
@@ -656,7 +656,7 @@ CUBIC MAY implement an algorithm to detect spurious retransmissions,
 such as DSACK {{?RFC3708}}, Forward RTO-Recovery {{?RFC5682}} or
 Eifel {{?RFC3522}}. Once a spurious loss event is detected, CUBIC SHOULD
 restore the original values of above mentioned variables as follows if
-the current cwnd is lower than the prior_cwnd. Restoring to the original
+the current *cwnd* is lower than *prior_cwnd*. Restoring to the original
 values ensures that CUBIC's performance is similar to what it would be
 if there were no spurious losses.
 
@@ -676,23 +676,23 @@ W_{est} = prior\_W_{est} \\
 {: artwork-align="center" }
 
 In rare cases, when the detection happens long after a spurious loss event
-and the current cwnd is already higher than the prior_cwnd, CUBIC SHOULD
+and the current *cwnd* is already higher than the *prior_cwnd*, CUBIC SHOULD
 continue to use the current and the most recent values of these variables.
 
 ## Slow Start
 
-CUBIC MUST employ a slow-start algorithm, when the cwnd is no more
-than ssthresh. Among the slow-start algorithms, CUBIC MAY choose the
+CUBIC MUST employ a slow-start algorithm, when *cwnd* is no more
+than *ssthresh*. Among the slow-start algorithms, CUBIC MAY choose the
 standard TCP slow start {{!RFC5681}} in general networks, or the limited
 slow start {{?RFC3742}} or hybrid slow start {{HR08}} for fast and long-
 distance networks.
 
 In the case when CUBIC runs the hybrid slow start {{HR08}}, it may exit
-the first slow start without incurring any packet loss and thus W<sub>max</sub>
+the first slow start without incurring any packet loss and thus *W<sub>max</sub>*
 is undefined. In this special case, CUBIC switches to congestion
 avoidance and increases its congestion window size using {{eq1}}, where
 t is the elapsed time since the beginning of the current congestion
-avoidance, K is set to 0, and W<sub>max</sub> is set to the congestion window
+avoidance, *K* is set to 0, and *W<sub>max</sub>* is set to the congestion window
 size at the beginning of the current congestion avoidance.
 
 # Discussion {#discussion}
@@ -701,7 +701,7 @@ In this section, we further discuss the safety features of CUBIC
 following the guidelines specified in {{!RFC5033}}.
 
 With a deterministic loss model where the number of packets between
-two successive packet losses is always 1/p, CUBIC always operates
+two successive packet losses is always *1/p*, CUBIC always operates
 with the concave window profile, which greatly simplifies the
 performance analysis of CUBIC. The average window size of CUBIC can
 be obtained by the following function:
@@ -711,7 +711,7 @@ AVG\_W_{cubic} = \sqrt[4]{\frac{C * (3 + β_{cubic})}{4 * (1 - β_{cubic})}} * \
 ~~~
 {: #eq5 artwork-align="center" }
 
-With {{{β}{}}}<sub>cubic</sub> set to 0.7, the above formula is reduced to:
+With *{{{β}{}}}<sub>cubic</sub>* set to 0.7, the above formula is reduced to:
 
 ~~~ math
 AVG\_W_{cubic} = \sqrt[4]{\frac{C * 3.7}{1.2}} *
@@ -719,7 +719,7 @@ AVG\_W_{cubic} = \sqrt[4]{\frac{C * 3.7}{1.2}} *
 ~~~
 {: #eq6 artwork-align="center" }
 
-We will determine the value of C in the following subsection using
+We will determine the value of *C* in the following subsection using
 {{eq6}}.
 
 ## Fairness to Standard TCP
@@ -739,7 +739,7 @@ above two types of networks. The following two tables show the
 average window sizes of Standard TCP, HSTCP, and CUBIC. The average
 window sizes of Standard TCP and HSTCP are from {{?RFC3649}}. The
 average window size of CUBIC is calculated using {{eq6}} and the CUBIC
-TCP-friendly region for three different values of C.
+TCP-friendly region for three different values of *C*.
 
 | Loss Rate P | TCP | HSTCP | CUBIC (C=0.04) | CUBIC (C=0.4) | CUBIC (C=4) |
 | ---:| ---:| ---:| ---:| ---:| ---:|
@@ -771,24 +771,24 @@ in MSS-sized segments.
 CUBIC in networks with RTT = 0.01 seconds. The average window size
 is in MSS-sized segments.
 
-Both tables show that CUBIC with any of these three C values is more
+Both tables show that CUBIC with any of these three *C* values is more
 friendly to TCP than HSTCP, especially in networks with a short RTT
 where TCP performs reasonably well. For example, in a network with
 RTT = 0.01 seconds and p=10^-6, TCP has an average window of 1200
 packets. If the packet size is 1500 bytes, then TCP can achieve an
-average rate of 1.44 Gbps. In this case, CUBIC with C=0.04 or C=0.4
+average rate of 1.44 Gbps. In this case, CUBIC with *C*=0.04 or *C*=0.4
 achieves exactly the same rate as Standard TCP, whereas HSTCP is
 about ten times more aggressive than Standard TCP.
 
-We can see that C determines the aggressiveness of CUBIC in competing
+We can see that *C* determines the aggressiveness of CUBIC in competing
 with other congestion control algorithms for bandwidth. CUBIC is
-more friendly to Standard TCP, if the value of C is lower. However,
-we do not recommend setting C to a very low value like 0.04, since
-CUBIC with a low C cannot efficiently use the bandwidth in long RTT
+more friendly to Standard TCP, if the value of *C* is lower. However,
+we do not recommend setting *C* to a very low value like 0.04, since
+CUBIC with a low *C* cannot efficiently use the bandwidth in long RTT
 and high-bandwidth networks. Based on these observations and our
-experiments, we find C=0.4 gives a good balance between TCP-
-friendliness and aggressiveness of window increase. Therefore, C
-SHOULD be set to 0.4. With C set to 0.4, {{eq6}} is reduced to:
+experiments, we find *C*=0.4 gives a good balance between TCP-
+friendliness and aggressiveness of window increase. Therefore, *C*
+SHOULD be set to 0.4. With *C* set to 0.4, {{eq6}} is reduced to:
 
 ~~~ math
 AVG\_W_{cubic} = 1.054 * \frac{\sqrt[3]{RTT^4}}{\sqrt[3]{p^4}}
@@ -869,7 +869,7 @@ This is not considered in the current CUBIC.
 
 CUBIC does not raise its congestion window size if the flow is
 currently limited by the application instead of the congestion
-window. In case of long periods when cwnd has not been updated due
+window. In case of long periods when *cwnd* has not been updated due
 to the application rate limit, such as idle periods, t in {{eq1}} MUST
 NOT include these periods; otherwise, W<sub>cubic</sub>(t) might be very high
 after restarting from these periods.
@@ -915,25 +915,25 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 
 - acknowledge former co-authors
   ([#15](https://github.com/NTAP/rfc8312bis/issues/15))
-- prevent cwnd from becoming less than two
+- prevent *cwnd* from becoming less than two
   ([#7](https://github.com/NTAP/rfc8312bis/issues/7))
 - add list of variables and constants
   ([#5](https://github.com/NTAP/rfc8312bis/issues/5),
   [#6](https://github.com/NTAP/rfc8312bis/issues/5))
-- update K's definition and add bounds for CUBIC target cwnd
+- update *K*'s definition and add bounds for CUBIC *target* *cwnd*
   ([#1](https://github.com/NTAP/rfc8312bis/issues/1),
   [#14](https://github.com/NTAP/rfc8312bis/issues/14))
-- update W<sub>est</sub> to use AIMD approach
+- update *W<sub>est</sub>* to use AIMD approach
   ([#20](https://github.com/NTAP/rfc8312bis/issues/20))
 - set <!-- xml2rfc cannot handdle this here: {{{α}{}}} -->alpha<sub>aimd</sub>
-  to 1 once W<sub>est</sub> reaches W<sub>max</sub>
+  to 1 once *W<sub>est</sub>* reaches *W<sub>max</sub>*
   ([#2](https://github.com/NTAP/rfc8312bis/issues/2))
 - add Vidhi as co-author ([#17](https://github.com/NTAP/rfc8312bis/issues/17))
-- note for fast recovery during cwnd decrease due to congestion event
+- note for fast recovery during *cwnd* decrease due to congestion event
   ([#11](https://github.com/NTAP/rfc8312bis11/issues/11))
 - add section for Spurious Loss events
   ([#23](https://github.com/NTAP/rfc8312bis/issues/23))
-- initialize W<sub>est</sub> after timeout and remove variable
+- initialize *W<sub>est</sub>* after timeout and remove variable
   W<sub>last_max</sub> ([#28](https://github.com/NTAP/rfc8312bis/issues/28))
 
 ## Since RFC8312

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -122,8 +122,8 @@ informative:
 
 CUBIC is an extension to the current TCP standards. It differs from
 the current TCP standards only in the congestion control algorithm on
-the sender side. In particular, it uses a cubic function instead of a
-linear window increase function of the current TCP standards to
+the sender side. In particular, it uses a cubic function instead of
+a linear window increase function of the current TCP standards to
 improve scalability and stability under fast and long-distance
 networks. CUBIC and its predecessor algorithm have been adopted as
 defaults by Linux and have been used for many years. This document
@@ -136,49 +136,49 @@ CUBIC to conform to the current Linux version.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the [TCPM working group
-mailing list](mailto:tcpm@ietf.org), which is archived at
+Discussion of this draft takes place on the [TCPM working group mailing
+list](mailto:tcpm@ietf.org), which is archived at
 [](https://mailarchive.ietf.org/arch/browse/tcpm/).
 
 Working Group information can be found at
-[](https://datatracker.ietf.org/wg/tcpm/); source code and issues list
-for this draft can be found at [](https://github.com/NTAP/rfc8312bis).
+[](https://datatracker.ietf.org/wg/tcpm/); source code and issues list for this
+draft can be found at [](https://github.com/NTAP/rfc8312bis).
 
 --- middle
 
 # Introduction
 
 The low utilization problem of TCP in fast long-distance networks is
-well documented in {{?K03}} and {{?RFC3649}}. This problem arises from
-a slow increase of the congestion window following a congestion event
+well documented in {{?K03}} and {{?RFC3649}}. This problem arises from a
+slow increase of the congestion window following a congestion event
 in a network with a large bandwidth-delay product (BDP). {{HKLRX06}}
 indicates that this problem is frequently observed even in the range
 of congestion window sizes over several hundreds of packets. This
 problem is equally applicable to all Reno-style TCP standards and
 their variants, including TCP-Reno {{!RFC5681}}, TCP-NewReno
-{{!RFC6582}}{{!RFC6675}}, SCTP {{?RFC4960}}, and TFRC {{!RFC5348}},
-which use the same linear increase function for window growth, which
-we refer to collectively as "Standard TCP" below.
+{{!RFC6582}}{{!RFC6675}}, SCTP {{?RFC4960}}, and TFRC {{!RFC5348}}, which
+use the same linear increase function for window growth, which we refer to
+collectively as "Standard TCP" below.
 
 CUBIC, originally proposed in {{?HRX08}}, is a modification to the
 congestion control algorithm of Standard TCP to remedy this problem.
 This document describes the most recent specification of CUBIC.
 Specifically, CUBIC uses a cubic function instead of a linear window
-increase function of Standard TCP to improve scalability and stability
-under fast and long-distance networks.
+increase function of Standard TCP to improve scalability and
+stability under fast and long-distance networks.
 
 Binary Increase Congestion Control (BIC-TCP) {{XHR04}}, a predecessor
-of CUBIC, was selected as the default TCP congestion control algorithm
-by Linux in the year 2005 and has been used for several years by the
-Internet community at large. CUBIC uses a similar window increase
-function as BIC-TCP and is designed to be less aggressive and fairer
-to Standard TCP in bandwidth usage than BIC-TCP while maintaining the
-strengths of BIC-TCP such as stability, window scalability, and RTT
-fairness. CUBIC has already replaced BIC-TCP as the default TCP
-congestion control algorithm in Linux and has been deployed globally
-by Linux. Through extensive testing in various Internet scenarios, we
-believe that CUBIC is safe for testing and deployment in the global
-Internet.
+of CUBIC, was selected as the default TCP congestion control
+algorithm by Linux in the year 2005 and has been used for several
+years by the Internet community at large. CUBIC uses a similar
+window increase function as BIC-TCP and is designed to be less
+aggressive and fairer to Standard TCP in bandwidth usage than BIC-TCP
+while maintaining the strengths of BIC-TCP such as stability, window
+scalability, and RTT fairness. CUBIC has already replaced BIC-TCP as
+the default TCP congestion control algorithm in Linux and has been
+deployed globally by Linux. Through extensive testing in various
+Internet scenarios, we believe that CUBIC is safe for testing and
+deployment in the global Internet.
 
 In the following sections, we first briefly explain the design
 principles of CUBIC, then provide the exact specification of CUBIC,
@@ -214,33 +214,32 @@ decrease factor in order to balance between the scalability and
 convergence speed.
 
 Principle 1: For better network utilization and stability, CUBIC
-{{?HRX08}} uses a cubic window increase function in terms of the
-elapsed time from the last congestion event. While most alternative
+{{?HRX08}} uses a cubic window increase function in terms of the elapsed
+time from the last congestion event. While most alternative
 congestion control algorithms to Standard TCP increase the congestion
 window using convex functions, CUBIC uses both the concave and convex
 profiles of a cubic function for window growth. After a window
 reduction in response to a congestion event is detected by duplicate
 ACKs or Explicit Congestion Notification-Echo (ECN-Echo) ACKs
 {{!RFC3168}}, CUBIC registers the congestion window size where it got
-the congestion event as W<sub>max</sub> and performs a multiplicative
-decrease of congestion window. After it enters into congestion
-avoidance, it starts to increase the congestion window using the
-concave profile of the cubic function. The cubic function is set to
-have its plateau at W<sub>max</sub> so that the concave window
-increase continues until the window size becomes W<sub>max</sub>.
-After that, the cubic function turns into a convex profile and the
-convex window increase begins. This style of window adjustment
-(concave and then convex) improves the algorithm stability while
-maintaining high network utilization {{?CEHRX07}}. This is because the
-window size remains almost constant, forming a plateau around
-W<sub>max</sub> where network utilization is deemed highest. Under
-steady state, most window size samples of CUBIC are close to
-W<sub>max</sub>, thus promoting high network utilization and
-stability. Note that those congestion control algorithms using only
-convex functions to increase the congestion window size have the
-maximum increments around W<sub>max</sub>, and thus introduce a large
-number of packet bursts around the saturation point of the network,
-likely causing frequent global loss synchronizations.
+the congestion event as W<sub>max</sub> and performs a multiplicative decrease
+of congestion window. After it enters into congestion avoidance, it
+starts to increase the congestion window using the concave profile of
+the cubic function. The cubic function is set to have its plateau at
+W<sub>max</sub> so that the concave window increase continues until the window
+size becomes W<sub>max</sub>. After that, the cubic function turns into a
+convex profile and the convex window increase begins. This style of
+window adjustment (concave and then convex) improves the algorithm
+stability while maintaining high network utilization {{?CEHRX07}}. This
+is because the window size remains almost constant, forming a plateau
+around W<sub>max</sub> where network utilization is deemed highest. Under
+steady state, most window size samples of CUBIC are close to W<sub>max</sub>,
+thus promoting high network utilization and stability. Note that
+those congestion control algorithms using only convex functions to
+increase the congestion window size have the maximum increments
+around W<sub>max</sub>, and thus introduce a large number of packet bursts
+around the saturation point of the network, likely causing frequent
+global loss synchronizations.
 
 Principle 2: CUBIC promotes per-flow fairness to Standard TCP. Note
 that Standard TCP performs well under short RTT and small bandwidth
@@ -248,55 +247,57 @@ that Standard TCP performs well under short RTT and small bandwidth
 networks with long RTTs and large bandwidth (or large BDP). An
 alternative congestion control algorithm to Standard TCP designed to
 be friendly to Standard TCP on a per-flow basis must operate to
-increase its congestion window less aggressively in small BDP networks
-than in large BDP networks. The aggressiveness of CUBIC mainly depends
-on the maximum window size before a window reduction, which is smaller
-in small BDP networks than in large BDP networks. Thus, CUBIC
-increases its congestion window less aggressively in small BDP
-networks than in large BDP networks. Furthermore, in cases when the
-cubic function of CUBIC increases its congestion window less
+increase its congestion window less aggressively in small BDP
+networks than in large BDP networks. The aggressiveness of CUBIC
+mainly depends on the maximum window size before a window reduction,
+which is smaller in small BDP networks than in large BDP networks.
+Thus, CUBIC increases its congestion window less aggressively in
+small BDP networks than in large BDP networks. Furthermore, in cases
+when the cubic function of CUBIC increases its congestion window less
 aggressively than Standard TCP, CUBIC simply follows the window size
 of Standard TCP to ensure that CUBIC achieves at least the same
-throughput as Standard TCP in small BDP networks. We call this region
-where CUBIC behaves like Standard TCP, the "TCP-friendly region".
+throughput as Standard TCP in small BDP networks. We call this
+region where CUBIC behaves like Standard TCP, the "TCP-friendly
+region".
 
-Principle 3: Two CUBIC flows with different RTTs have their throughput
-ratio linearly proportional to the inverse of their RTT ratio, where
-the throughput of a flow is approximately the size of its congestion
-window divided by its RTT. Specifically, CUBIC maintains a window
-increase rate independent of RTTs outside of the TCP-friendly region,
-and thus flows with different RTTs have similar congestion window
-sizes under steady state when they operate outside the TCP-friendly
-region. This notion of a linear throughput ratio is similar to that of
-Standard TCP under high statistical multiplexing environments where
-packet losses are independent of individual flow rates. However, under
-low statistical multiplexing environments, the throughput ratio of
-Standard TCP flows with different RTTs is quadratically proportional
-to the inverse of their RTT ratio {{XHR04}}. CUBIC always ensures the
-linear throughput ratio independent of the levels of statistical
-multiplexing. This is an improvement over Standard TCP. While there is
-no consensus on particular throughput ratios of different RTT flows,
-we believe that under wired Internet, use of a linear throughput ratio
-seems more reasonable than equal throughputs (i.e., the same
-throughput for flows with different RTTs) or a higher-order throughput
-ratio (e.g., a quadratical throughput ratio of Standard TCP under low
-statistical multiplexing environments).
+Principle 3: Two CUBIC flows with different RTTs have their
+throughput ratio linearly proportional to the inverse of their RTT
+ratio, where the throughput of a flow is approximately the size of
+its congestion window divided by its RTT. Specifically, CUBIC
+maintains a window increase rate independent of RTTs outside of the
+TCP-friendly region, and thus flows with different RTTs have similar
+congestion window sizes under steady state when they operate outside
+the TCP-friendly region. This notion of a linear throughput ratio is
+similar to that of Standard TCP under high statistical multiplexing
+environments where packet losses are independent of individual flow
+rates. However, under low statistical multiplexing environments, the
+throughput ratio of Standard TCP flows with different RTTs is
+quadratically proportional to the inverse of their RTT ratio {{XHR04}}.
+CUBIC always ensures the linear throughput ratio independent of the
+levels of statistical multiplexing. This is an improvement over
+Standard TCP. While there is no consensus on particular throughput
+ratios of different RTT flows, we believe that under wired Internet,
+use of a linear throughput ratio seems more reasonable than equal
+throughputs (i.e., the same throughput for flows with different RTTs)
+or a higher-order throughput ratio (e.g., a quadratical throughput
+ratio of Standard TCP under low statistical multiplexing
+environments).
 
-Principle 4: To balance between the scalability and convergence speed,
-CUBIC sets the multiplicative window decrease factor to 0.7 while
-Standard TCP uses 0.5. While this improves the scalability of CUBIC, a
-side effect of this decision is slower convergence, especially under
-low statistical multiplexing environments. This design choice is
-following the observation that the author of HighSpeed TCP (HSTCP)
-{{?RFC3649}} has made along with other researchers (e.g., {{GV02}}):
-the current Internet becomes more asynchronous with less frequent loss
-synchronizations with high statistical multiplexing. Under this
-environment, even strict Multiplicative-Increase
-Multiplicative-Decrease (MIMD) can converge. CUBIC flows with the same
-RTT always converge to the same throughput independent of statistical
-multiplexing, thus achieving intra-algorithm fairness. We also find
-that under the environments with sufficient statistical multiplexing,
-the convergence speed of CUBIC flows is reasonable.
+Principle 4: To balance between the scalability and convergence
+speed, CUBIC sets the multiplicative window decrease factor to 0.7
+while Standard TCP uses 0.5. While this improves the scalability of
+CUBIC, a side effect of this decision is slower convergence,
+especially under low statistical multiplexing environments. This
+design choice is following the observation that the author of
+HighSpeed TCP (HSTCP) {{?RFC3649}} has made along with other researchers
+(e.g., {{GV02}}): the current Internet becomes more asynchronous with
+less frequent loss synchronizations with high statistical
+multiplexing. Under this environment, even strict Multiplicative-Increase
+Multiplicative-Decrease (MIMD) can converge. CUBIC flows
+with the same RTT always converge to the same throughput independent
+of statistical multiplexing, thus achieving intra-algorithm fairness.
+We also find that under the environments with sufficient statistical
+multiplexing, the convergence speed of CUBIC flows is reasonable.
 
 # CUBIC Congestion Control
 
@@ -310,14 +311,14 @@ maximum segment size (MSS), and the unit of all times is seconds.
 
 ### Constants of interest
 
-<!--{{{β}{}}}-->beta<sub>cubic</sub>:
-: CUBIC multiplication decrease factor as described in {{mult-dec}}
+{{{β}{}}}<sub>cubic</sub>:
+CUBIC multiplication decrease factor as described in {{mult-dec}}
 
 C:
-: constant that determines the aggressiveness of CUBIC in competing
-  with other congestion control algorithms in high BDP networks. Please
-  see {{discussion}} for more explanation on how it is set. The unit for
-  C is
+constant that determines the aggressiveness of CUBIC in competing
+with other congestion control algorithms in high BDP networks. Please see
+{{discussion}} for more explanation on how it is set. The unit for
+C is
 
 ~~~ math
 \frac{segment}{second^3}
@@ -329,52 +330,51 @@ C:
 Variables required to implement CUBIC are described in this section.
 
 RTT:
-: Smoothed round-trip time in seconds calculated as described in
-  {{!RFC6298}}
+Smoothed round-trip time in seconds calculated as described in {{!RFC6298}}
 
 cwnd:
-: Current congestion window in segments
+Current congestion window in segments
 
 ssthresh:
-: Current slow start threshold in segments
+Current slow start threshold in segments
 
 W<sub>max</sub>:
-: Size of the cwnd in segments just before the cwnd is reduced in the
-  last congestion event
+Size of the cwnd in segments just before the cwnd is reduced in the
+last congestion event
 
 K:
-: The time period in seconds it takes to increase the current congestion
-  window size to W<sub>max</sub>
+The time period in seconds it takes to increase the current congestion
+window size to W<sub>max</sub>
 
-current_time
-: Current time of the system in seconds
+current_time:
+Current time of the system in seconds
 
 epoch_start:
-: The time in seconds at which the current congestion avoidance stage starts
+The time in seconds at which the current congestion avoidance stage starts
 
 W<sub>cubic</sub>(t):
-: Target value of the congestion window in segments at time t in seconds
-  based on the cubic increase function as described in {{win-inc}}
+Target value of the congestion window in segments at time t in seconds
+based on the cubic increase function as described in {{win-inc}}
 
 target:
-: Target value of congestion window in segments after the next RTT,
-  that is, W<sub>cubic</sub>(t + RTT) as described in {{win-inc}}
+Target value of congestion window in segments after the next RTT,
+that is, W<sub>cubic</sub>(t + RTT) as described in {{win-inc}}
 
 W<sub>est</sub>:
-: An estimate for the congestion window in segments in the
-  TCP-friendly region, that is, an estimate for the congestion window
-  using the AIMD approach similar to TCP-NewReno congestion controller
+An estimate for the congestion window in segments in the TCP-friendly
+region, that is, an estimate for the congestion window using the AIMD
+approach similar to TCP-NewReno congestion controller
 
 ## Window Increase Function {#win-inc}
 
 CUBIC maintains the acknowledgment (ACK) clocking of Standard TCP by
 increasing the congestion window only at the reception of an ACK. It
 does not make any change to the fast recovery and retransmit of TCP,
-such as TCP-NewReno {{!RFC6582}}{{!RFC6675}}. During congestion
-avoidance after a congestion event where a packet loss is detected by
-duplicate ACKs or a network congestion is detected by ACKs with
-ECN-Echo flags {{!RFC3168}}, CUBIC changes the window increase
-function of Standard TCP.
+such as TCP-NewReno {{!RFC6582}}{{!RFC6675}}. During congestion avoidance
+after a congestion event where a packet loss is detected by duplicate
+ACKs or a network congestion is detected by ACKs with ECN-Echo flags
+{{!RFC3168}}, CUBIC changes the window increase function of Standard
+TCP.
 
 CUBIC uses the following window increase function:
 
@@ -384,10 +384,16 @@ CUBIC uses the following window increase function:
 {: #eq1 artwork-align="center" }
 
 where t is the elapsed time in seconds from the beginning of the
-current congestion avoidance stage, that is, t = (current_time -
-epoch_start), where epoch_start is the time at which the current
+current congestion avoidance stage, that is,
+
+~~~ math
+t = current\_time - epoch\_start
+~~~
+{: artwork-align="center" }
+
+where epoch_start is the time at which the current
 congestion avoidance stage starts. K is the time period that the
-above function takes to increase the current window size to W_max
+above function takes to increase the current window size to W<sub>max</sub>
 if there are no further congestion events and is calculated using
 the following equation:
 
@@ -405,9 +411,9 @@ W<sub>max</sub>, K is set to 0.
 
 Upon receiving an ACK during congestion avoidance, CUBIC computes the
 target congestion window size after the next RTT using {{eq1}} as
-follows, where RTT is the smoothed round-trip time. The lower and
-upper bounds below ensure that CUBIC's congestion window increase rate
-is non-decreasing and is less than the increase rate of slow start.
+follows, where RTT is the smoothed round-trip time. The lower and upper
+bounds below ensure that CUBIC's congestion window increase rate is
+non-decreasing and is less than the increase rate of slow start.
 
 ~~~ math
 target = \left\{
@@ -425,11 +431,11 @@ cwnd                          &
 Depending on the value of the current congestion window size cwnd,
 CUBIC runs in three different modes.
 
-1. The TCP-friendly region, which ensures that CUBIC achieves at least
-   the same throughput as Standard TCP.
+1. The TCP-friendly region, which ensures that CUBIC achieves at
+   least the same throughput as Standard TCP.
 
-2. The concave region, if CUBIC is not in the TCP-friendly region and
-   cwnd is less than W<sub>max</sub>.
+2. The concave region, if CUBIC is not in the TCP-friendly region
+   and cwnd is less than W<sub>max</sub>.
 
 3. The convex region, if CUBIC is not in the TCP-friendly region and
    cwnd is greater than W<sub>max</sub>.
@@ -439,14 +445,14 @@ Below, we describe the exact actions taken by CUBIC in each region.
 ## TCP-Friendly Region
 
 Standard TCP performs well in certain types of networks, for example,
-under short RTT and small bandwidth (or small BDP) networks. In these
-networks, we use the TCP-friendly region to ensure that CUBIC achieves
-at least the same throughput as Standard TCP.
+under short RTT and small bandwidth (or small BDP) networks. In
+these networks, we use the TCP-friendly region to ensure that CUBIC
+achieves at least the same throughput as Standard TCP.
 
 The TCP-friendly region is designed according to the analysis
 described in {{FHP00}}. The analysis studies the performance of an
-Additive Increase and Multiplicative Decrease (AIMD) algorithm with an
-additive factor of {{{α}{}}}<sub>aimd</sub> (segments per RTT) and a
+Additive Increase and Multiplicative Decrease (AIMD) algorithm with
+an additive factor of {{{α}{}}}<sub>aimd</sub> (segments per RTT) and a
 multiplicative factor of {{{β}{}}}<sub>aimd</sub>, denoted by
 AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>).
 Specifically, the average congestion window size of
@@ -459,10 +465,11 @@ AIMD({{{α}{}}}<sub>aimd</sub>, {{{β}{}}}<sub>aimd</sub>) with
 ~~~
 {: artwork-align="center" }
 
-achieves the same average window size as Standard TCP that uses AIMD(1, 0.5).
+achieves the same average
+window size as Standard TCP that uses AIMD(1, 0.5).
 
 ~~~ math
-\mathrm{AIMD}(α_{aimd}, β_{aimd}) =
+\mathrm{AVG\_AIMD}(α_{aimd}, β_{aimd}) =
     \sqrt{\frac{α_{aimd} * (1 + β_{aimd})}{2 * (1 - β_{aimd}) * p}}
 ~~~
 {: #eq3 artwork-align="center" }
@@ -486,51 +493,56 @@ W<sub>cubic</sub>(t) is less than W<sub>est</sub>. If so, CUBIC is in
 the TCP-friendly region and cwnd SHOULD be set to W<sub>est</sub> at
 each reception of an ACK.
 
-W<sub>est</sub> is set equal to cwnd at the start of the congestion
-avoidance stage. After that, on every ACK, W<sub>est</sub> is updated
-using {{eq4}}.
+W<sub>est</sub> is set equal to cwnd at the start of the congestion avoidance
+stage. After that, on every ACK, W<sub>est</sub> is updated using {{eq4}}.
 
 ~~~ math
-W_{est} = W_{est} + α_{aimd} * \frac{segments_{acked}}{cwnd}
+W_{est} = W_{est} + α_{aimd} * \frac{segments\_acked}{cwnd}
 ~~~
 {: #eq4 artwork-align="center" }
 
 Note that once W<sub>est</sub> reaches W<sub>max</sub>, that is,
 W<sub>est</sub> >= W<sub>max</sub>, {{{α}{}}}<sub>aimd</sub> SHOULD be
-set to 1 to achieve the same congestion window size as standard TCP
-that uses AIMD.
+set to 1 to achieve the same congestion
+window size as standard TCP that uses AIMD.
 
 ## Concave Region
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is less than W<sub>max</sub>, then CUBIC
-is in the concave region. In this region, cwnd MUST be incremented by
+TCP-friendly region and cwnd is less than W<sub>max</sub>, then CUBIC is in the
+concave region. In this region, cwnd MUST be incremented by
 
 ~~~ math
 \frac{target - cwnd}{cwnd}
 ~~~
 {: artwork-align="center" }
 
-for each received ACK, where target is calculated as described in
-{{win-inc}}.
+for each received ACK, where target is
+calculated as described in {{win-inc}}.
 
-## Convex Region
+## Convex Region {#convex-region}
 
 When receiving an ACK in congestion avoidance, if CUBIC is not in the
-TCP-friendly region and cwnd is larger than or equal to
-W<sub>max</sub>, then CUBIC is in the convex region. The convex region
-indicates that the network conditions might have been perturbed since
-the last congestion event, possibly implying more available bandwidth
-after some flow departures. Since the Internet is highly asynchronous,
-some amount of perturbation is always possible without causing a major
-change in available bandwidth. In this region, CUBIC is being very
-careful by very slowly increasing its window size. The convex profile
-ensures that the window increases very slowly at the beginning and
-gradually increases its increase rate. We also call this region the
-"maximum probing phase" since CUBIC is searching for a new
-W<sub>max</sub>. In this region, cwnd MUST be incremented by (target -
-cwnd)/cwnd for each received ACK, where target is calculated as
-described in {{win-inc}}.
+TCP-friendly region and cwnd is larger than or equal to W<sub>max</sub>, then
+CUBIC is in the convex region. The convex region indicates that the
+network conditions might have been perturbed since the last
+congestion event, possibly implying more available bandwidth after
+some flow departures. Since the Internet is highly asynchronous,
+some amount of perturbation is always possible without causing a
+major change in available bandwidth. In this region, CUBIC is being
+very careful by very slowly increasing its window size. The convex
+profile ensures that the window increases very slowly at the
+beginning and gradually increases its increase rate. We also call
+this region the "maximum probing phase" since CUBIC is searching for
+a new W<sub>max</sub>. In this region, cwnd MUST be incremented by
+
+~~~ math
+\frac{target - cwnd}{cwnd}
+~~~
+{: artwork-align="center" }
+
+for each received ACK, where target is
+calculated as described in {{win-inc}}.
 
 ## Multiplicative Decrease {#mult-dec}
 
@@ -555,11 +567,11 @@ cwnd = ssthresh &
 {: artwork-align="center" }
 
 A side effect of setting {{{β}{}}}<sub>cubic</sub> to a value bigger
-than 0.5 is slower convergence. We believe that while a more adaptive
-setting of {{{β}{}}}<sub>cubic</sub> could result in faster
-convergence, it will make the analysis of CUBIC much harder. This
-adaptive adjustment of {{{β}{}}}<sub>cubic</sub> is an item for the
-next version of CUBIC.
+than 0.5 is
+slower convergence. We believe that while a more adaptive setting of
+{{{β}{}}}<sub>cubic</sub> could result in faster convergence, it will make the
+analysis of CUBIC much harder. This adaptive adjustment of
+{{{β}{}}}<sub>cubic</sub> is an item for the next version of CUBIC.
 
 ## Fast Convergence
 
@@ -571,8 +583,8 @@ bandwidth of the network. To speed up this bandwidth release by
 existing flows, the following mechanism called "fast convergence"
 SHOULD be implemented.
 
-With fast convergence, when a congestion event occurs, we update W_max
-as follows before the window reduction as described in Section 4.5.
+With fast convergence, when a congestion event occurs, we update W<sub>max</sub>
+as follows before the window reduction as described in {{convex-region}}.
 
 ~~~ math
 W_{max} = \left\{
@@ -595,15 +607,15 @@ the plateau earlier.  This allows more time for the new flow to catch
 up to its congestion window size.
 
 The fast convergence is designed for network environments with
-multiple CUBIC flows. In network environments with only a single CUBIC
-flow and without any other traffic, the fast convergence SHOULD be
-disabled.
+multiple CUBIC flows. In network environments with only a single
+CUBIC flow and without any other traffic, the fast convergence SHOULD
+be disabled.
 
 ## Timeout
 
 In case of timeout, CUBIC follows Standard TCP to reduce cwnd
-{{!RFC5681}}, but sets ssthresh using {{{β}{}}}<sub>cubic</sub> (same
-as in {{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
+{{!RFC5681}}, but sets ssthresh using {{{β}{}}}<sub>cubic</sub> (same as in
+{{mult-dec}}) that is different from Standard TCP {{!RFC5681}}.
 
 During the first congestion avoidance after a timeout, CUBIC
 increases its congestion window size using Eq. 1, where t is the
@@ -628,13 +640,15 @@ performance significantly.
 When there is a loss event, A CUBIC implementation SHOULD save the current
 value of the following variables before the congestion window reduction.
 
-~~~
-    prior_cwnd = cwnd
-    prior_ssthresh = ssthresh
-    prior_W_max = W_max
-    prior_K = K
-    prior_epoch_start = epoch_start
-    prior_W_est = W_est
+~~~ math
+\begin{array}{l}
+prior\_cwnd = cwnd \\
+prior\_ssthresh = ssthresh \\
+prior\_W_{max} = W_{max} \\
+prior\_K = K \\
+prior\_epoch\_start = epoch\_start \\
+prior\_W\_{est} = W_{est} \\
+\end{array}
 ~~~
 {: artwork-align="center" }
 
@@ -646,16 +660,20 @@ the current cwnd is lower than the prior_cwnd. Restoring to the original
 values ensures that CUBIC's performance is similar to what it would be
 if there were no spurious losses.
 
+~~~ math
+\left.
+\begin{array}{l}
+cwnd = prior\_cwnd \\
+ssthresh = prior\_ssthresh \\
+W_{max} = prior\_W_{max} \\
+K = prior\_K \\
+epoch\_start = prior\_epoch\_start \\
+W_{est} = prior\_W_{est} \\
+\end{array}
+\right\}
+\text{if }cwnd < prior\_cwnd
 ~~~
-    if (cwnd < prior_cwnd) {
-        cwnd = prior_cwnd
-        ssthresh = prior_ssthresh
-        W_max = prior_W_max
-        K = prior_K
-        epoch_start = prior_epoch_start
-        W_est = prior_W_est
-    }
-~~~
+{: artwork-align="center" }
 
 In rare cases, when the detection happens long after a spurious loss event
 and the current cwnd is already higher than the prior_cwnd, CUBIC SHOULD
@@ -665,18 +683,17 @@ continue to use the current and the most recent values of these variables.
 
 CUBIC MUST employ a slow-start algorithm, when the cwnd is no more
 than ssthresh. Among the slow-start algorithms, CUBIC MAY choose the
-standard TCP slow start {{!RFC5681}} in general networks, or the
-limited slow start {{?RFC3742}} or hybrid slow start {{HR08}} for fast
-and long- distance networks.
+standard TCP slow start {{!RFC5681}} in general networks, or the limited
+slow start {{?RFC3742}} or hybrid slow start {{HR08}} for fast and long-
+distance networks.
 
-In the case when CUBIC runs the hybrid slow start {{HR08}}, it may
-exit the first slow start without incurring any packet loss and thus
-W<sub>max</sub> is undefined. In this special case, CUBIC switches to
-congestion avoidance and increases its congestion window size using
-{{eq1}}, where t is the elapsed time since the beginning of the
-current congestion avoidance, K is set to 0, and W<sub>max</sub> is
-set to the congestion window size at the beginning of the current
-congestion avoidance.
+In the case when CUBIC runs the hybrid slow start {{HR08}}, it may exit
+the first slow start without incurring any packet loss and thus W<sub>max</sub>
+is undefined. In this special case, CUBIC switches to congestion
+avoidance and increases its congestion window size using {{eq1}}, where
+t is the elapsed time since the beginning of the current congestion
+avoidance, K is set to 0, and W<sub>max</sub> is set to the congestion window
+size at the beginning of the current congestion avoidance.
 
 # Discussion {#discussion}
 
@@ -684,10 +701,10 @@ In this section, we further discuss the safety features of CUBIC
 following the guidelines specified in {{!RFC5033}}.
 
 With a deterministic loss model where the number of packets between
-two successive packet losses is always 1/p, CUBIC always operates with
-the concave window profile, which greatly simplifies the performance
-analysis of CUBIC. The average window size of CUBIC can be obtained by
-the following function:
+two successive packet losses is always 1/p, CUBIC always operates
+with the concave window profile, which greatly simplifies the
+performance analysis of CUBIC. The average window size of CUBIC can
+be obtained by the following function:
 
 ~~~ math
 AVG\_W_{cubic} = \sqrt[4]{\frac{C * (3 + β_{cubic})}{4 * (1 - β_{cubic})}} * \frac{\sqrt[3]{RTT^4}}{\sqrt[3]{p^4}}
@@ -718,10 +735,10 @@ Standard TCP performs well in the following two types of networks:
 2. networks with a short RTTs, but not necessarily a small BDP
 
 CUBIC is designed to behave very similarly to Standard TCP in the
-above two types of networks. The following two tables show the average
-window sizes of Standard TCP, HSTCP, and CUBIC. The average window
-sizes of Standard TCP and HSTCP are from {{?RFC3649}}. The average
-window size of CUBIC is calculated using {{eq6}} and the CUBIC
+above two types of networks. The following two tables show the
+average window sizes of Standard TCP, HSTCP, and CUBIC. The average
+window sizes of Standard TCP and HSTCP are from {{?RFC3649}}. The
+average window size of CUBIC is calculated using {{eq6}} and the CUBIC
 TCP-friendly region for three different values of C.
 
 | Loss Rate P | TCP | HSTCP | CUBIC (C=0.04) | CUBIC (C=0.4) | CUBIC (C=4) |
@@ -756,19 +773,19 @@ is in MSS-sized segments.
 
 Both tables show that CUBIC with any of these three C values is more
 friendly to TCP than HSTCP, especially in networks with a short RTT
-where TCP performs reasonably well. For example, in a network with RTT
-= 0.01 seconds and p=10^-6, TCP has an average window of 1200 packets.
-If the packet size is 1500 bytes, then TCP can achieve an average rate
-of 1.44 Gbps. In this case, CUBIC with C=0.04 or C=0.4 achieves
-exactly the same rate as Standard TCP, whereas HSTCP is about ten
-times more aggressive than Standard TCP.
+where TCP performs reasonably well. For example, in a network with
+RTT = 0.01 seconds and p=10^-6, TCP has an average window of 1200
+packets. If the packet size is 1500 bytes, then TCP can achieve an
+average rate of 1.44 Gbps. In this case, CUBIC with C=0.04 or C=0.4
+achieves exactly the same rate as Standard TCP, whereas HSTCP is
+about ten times more aggressive than Standard TCP.
 
 We can see that C determines the aggressiveness of CUBIC in competing
-with other congestion control algorithms for bandwidth. CUBIC is more
-friendly to Standard TCP, if the value of C is lower. However, we do
-not recommend setting C to a very low value like 0.04, since CUBIC
-with a low C cannot efficiently use the bandwidth in long RTT and
-high-bandwidth networks. Based on these observations and our
+with other congestion control algorithms for bandwidth. CUBIC is
+more friendly to Standard TCP, if the value of C is lower. However,
+we do not recommend setting C to a very low value like 0.04, since
+CUBIC with a low C cannot efficiently use the bandwidth in long RTT
+and high-bandwidth networks. Based on these observations and our
 experiments, we find C=0.4 gives a good balance between TCP-
 friendliness and aggressiveness of window increase. Therefore, C
 SHOULD be set to 0.4. With C set to 0.4, {{eq6}} is reduced to:
@@ -825,16 +842,16 @@ algorithm. Because CUBIC is designed to be more aggressive (due to a
 faster window increase function and bigger multiplicative decrease
 factor) than Standard TCP in fast and long-distance networks, it can
 fill large drop-tail buffers more quickly than Standard TCP and
-increase the risk of a standing queue {{?RFC8511}}. In this case,
-proper queue sizing and management {{!RFC7567}} could be used to
-reduce the packet queuing delay.
+increase the risk of a standing queue {{?RFC8511}}. In this case, proper
+queue sizing and management {{!RFC7567}} could be used to reduce the
+packet queuing delay.
 
 ## Protection against Congestion Collapse
 
 With regard to the potential of causing congestion collapse, CUBIC
 behaves like Standard TCP since CUBIC modifies only the window
-adjustment algorithm of TCP. Thus, it does not modify the ACK clocking
-and Timeout behaviors of Standard TCP.
+adjustment algorithm of TCP. Thus, it does not modify the ACK
+clocking and Timeout behaviors of Standard TCP.
 
 ## Fairness within the Alternative Congestion Control Algorithm
 
@@ -851,11 +868,11 @@ This is not considered in the current CUBIC.
 ## Behavior for Application-Limited Flows
 
 CUBIC does not raise its congestion window size if the flow is
-currently limited by the application instead of the congestion window.
-In case of long periods when cwnd has not been updated due to the
-application rate limit, such as idle periods, t in {{eq1}} MUST NOT
-include these periods; otherwise, W<sub>cubic</sub>(t) might be very
-high after restarting from these periods.
+currently limited by the application instead of the congestion
+window. In case of long periods when cwnd has not been updated due
+to the application rate limit, such as idle periods, t in {{eq1}} MUST
+NOT include these periods; otherwise, W<sub>cubic</sub>(t) might be very high
+after restarting from these periods.
 
 ## Responses to Sudden or Transient Events
 
@@ -865,15 +882,16 @@ event, CUBIC behaves the same as Standard TCP.
 ## Incremental Deployment
 
 CUBIC requires only the change of TCP senders, and it does not make
-any changes to TCP receivers. That is, a CUBIC sender works correctly
-with the Standard TCP receivers. In addition, CUBIC does not require
-any changes to the routers and does not require any assistance from
-the routers.
+any changes to TCP receivers. That is, a CUBIC sender works
+correctly with the Standard TCP receivers. In addition, CUBIC does
+not require any changes to the routers and does not require any
+assistance from the routers.
 
 # Security Considerations
 
-This proposal makes no changes to the underlying security of TCP. More
-information about TCP security concerns can be found in {{!RFC5681}}.
+This proposal makes no changes to the underlying security of TCP.
+More information about TCP security concerns can be found in
+{{!RFC5681}}.
 
 # IANA Considerations
 
@@ -905,7 +923,7 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 - update K's definition and add bounds for CUBIC target cwnd
   ([#1](https://github.com/NTAP/rfc8312bis/issues/1),
   [#14](https://github.com/NTAP/rfc8312bis/issues/14))
-- update W_est to use AIMD approach
+- update W<sub>est</sub> to use AIMD approach
   ([#20](https://github.com/NTAP/rfc8312bis/issues/20))
 - set <!-- xml2rfc cannot handdle this here: {{{α}{}}} -->alpha<sub>aimd</sub>
   to 1 once W<sub>est</sub> reaches W<sub>max</sub>
@@ -914,8 +932,9 @@ Richard Scheffenegger and Alexander Zimmermann originally co-authored
 - note for fast recovery during cwnd decrease due to congestion event
   ([#11](https://github.com/NTAP/rfc8312bis11/issues/11))
 - add section for Spurious Loss events
-  ([#23] (https://github.com/NTAP/rfc8312bis/issues/23))
-- initialize W_est after timeout and remove variable W_last_max ([#28](https://github.com/NTAP/rfc8312bis/issues/28))
+  ([#23](https://github.com/NTAP/rfc8312bis/issues/23))
+- initialize W<sub>est</sub> after timeout and remove variable
+  W<sub>last_max</sub> ([#28](https://github.com/NTAP/rfc8312bis/issues/28))
 
 ## Since RFC8312
 

--- a/draft-eggert-tcpm-rfc8312bis.md
+++ b/draft-eggert-tcpm-rfc8312bis.md
@@ -310,21 +310,19 @@ maximum segment size (MSS), and the unit of all times is seconds.
 
 ### Constants of interest
 
-{{{β}{}}}<sub>cubic</sub>:
+<!--{{{β}{}}}-->beta<sub>cubic</sub>:
 : CUBIC multiplication decrease factor as described in {{mult-dec}}
 
 C:
 : constant that determines the aggressiveness of CUBIC in competing
   with other congestion control algorithms in high BDP networks. Please
   see {{discussion}} for more explanation on how it is set. The unit for
-  C is segment / (second)^3
+  C is
 
-<!-- this does not work?
 ~~~ math
 \frac{segment}{second^3}
 ~~~
 {: artwork-align="center" }
--->
 
 ### Variables of interest
 


### PR DESCRIPTION
This uses the experimental `math` support in [kramdown-rfc2629](https://github.com/cabo/kramdown-rfc2629) to render Latex-style equations via [tex2svg](https://github.com/mathjax/mathjax-node-cli) and [asciitex](https://github.com/larseggert/asciiTeX).

I'm still working through some issues with the toolchain, so this isn't ready for merging yet, but I wanted to give you a preview.