### PR TITLE
Update draft-ietf-tcpm-rfc8312bis.md

### DIFF
--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1117,6 +1117,8 @@ These individuals suggested improvements to this document:
   ([#96](https://github.com/NTAP/rfc8312bis/issues/96))
 - Add more test results to Section 5 and update some references
   ([#91](https://github.com/NTAP/rfc8312bis/issues/91))
+- Change wording around setting ssthresh
+  ([#131](https://github.com/NTAP/rfc8312bis/issues/131))
 
 ## Since draft-ietf-tcpm-rfc8312bis-04
 

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -664,7 +664,7 @@ or periods when unable to send at the full rate permitted by *cwnd*
 may easily encounter notable variations in the volume of data sent
 from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
-much lower value than necessary. To avoid suboptimal performance with 
+much lower value than necessary. To avoid suboptimal performance with
 such applications, the mechanisms described in {{?RFC7661}} can be used 
 to mitigate this issue, would allow using a value between *cwnd* 
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}. 

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -668,7 +668,7 @@ much lower value than necessary. To avoid suboptimal performance with
 such applications, the mechanisms described in {{?RFC7661}} can be used 
 to mitigate this issue as it would allow using a value between *cwnd* 
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}. 
-Some implementations of CUBIC use *cwnd* when calculating a new *ssthresh*.
+Some implementations of CUBIC use *cwnd* instead of *flight_size* when calculating a new *ssthresh* using {{eqssthresh}}.
 
 ~~~ math
 \begin{array}{lll}

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -665,10 +665,11 @@ may easily encounter notable variations in the volume of data sent
 from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
 much lower value than necessary. To avoid suboptimal performance with
-such applications, the mechanisms described in {{?RFC7661}} can be used 
-to mitigate this issue as it would allow using a value between *cwnd* 
-and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}. 
-Some implementations of CUBIC use *cwnd* instead of *flight_size* when calculating a new *ssthresh* using {{eqssthresh}}.
+such applications, the mechanisms described in {{?RFC7661}} can be used
+to mitigate this issue as it would allow using a value between *cwnd*
+and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}.
+Some implementations of CUBIC use *cwnd* instead of *flight_size*
+when calculating a new *ssthresh* using {{eqssthresh}}.
 
 ~~~ math
 \begin{array}{lll}

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -664,11 +664,11 @@ or periods when unable to send at the full rate permitted by *cwnd*
 may easily encounter notable variations in the volume of data sent
 from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
-much lower value than necessary. To avoid suboptimal performance with
-such applications, some implementations of CUBIC use *cwnd* instead of
-*flight_size* to calculate the new *ssthresh* in {{eqssthresh}}.
-Alternatively, the mechanisms described in {{?RFC7661}} may also
-be adopted to mitigate this issue.
+much lower value than necessary. To avoid suboptimal performance with 
+such applications, the mechanisms described in {{?RFC7661}} can be used 
+to mitigate this issue, would allow using a value between *cwnd* 
+and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}. 
+Some implementations of CUBIC use *cwnd* when calculating a new *ssthresh*.
 
 ~~~ math
 \begin{array}{lll}

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -666,7 +666,7 @@ from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
 much lower value than necessary. To avoid suboptimal performance with
 such applications, the mechanisms described in {{?RFC7661}} can be used 
-to mitigate this issue, would allow using a value between *cwnd* 
+to mitigate this issue as it would allow using a value between *cwnd* 
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}. 
 Some implementations of CUBIC use *cwnd* when calculating a new *ssthresh*.
 


### PR DESCRIPTION
This PR is intended to amend the text to align with my understanding of the RFC-series. This normatively  would require ssthresh to be set from flight_size; however, this is explicitly relaxed in RFC7661, so I suggest wording should be careful around this topic. I retained the original text observation that in fact some cubic implementations are known to set ssthresh from cwnd.

Note:  I expected the REF to "RFC7661" to be informative (EXP).