### PR TITLE
rephrase "changes the window increase function of Reno"

### DIFF
--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -433,8 +433,8 @@ does not make any changes to the TCP Fast Recovery and Fast Retransmit
 algorithms {{!RFC6582}}{{!RFC6675}}.
 
 During congestion avoidance, after a congestion event is detected
-by mechanisms described in {{cubic-inc}}, CUBIC changes the window
-increase function of Reno.
+by mechanisms described in {{cubic-inc}}, CUBIC uses a window
+increase function different from Reno.
 
 CUBIC uses the following window increase function:
 


### PR DESCRIPTION
The phrase "changes the window increase function of Reno" is ambiguous, and could be
interpreted as implying that the document is changing Reno. This commit rephrases that
sentence to make it more clear that CUBIC does not change Reno but is simply
using an approach that's different from Reno.