### PR TITLE
clarify the meaning of "application-limited"

### DIFF
--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1089,6 +1089,8 @@ These individuals suggested improvements to this document:
 
 ## Since draft-ietf-tcpm-rfc8312bis-05
 
+- Clarify meaning of "application-limited" in Section 5.8
+  ([#137](https://github.com/NTAP/rfc8312bis/issues/137)
 - Brief discussion of convergence in Section 5.6
   ([#96](https://github.com/NTAP/rfc8312bis/issues/96))
 - Add more test results to Section 5 and update some references

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1016,8 +1016,7 @@ This can happen if the flow is limited by either the
 sender application or the receiver application (via the receiver
 advertised window) instead of the sender's congestion window.
 
-CUBIC does not 
-increase its congestion window if a flow is application-limited.
+CUBIC does not increase its congestion window if a flow is application-limited.
 {{win-inc}} requires that *t* in {{eq1}} does not include
 application-limited periods, such as idle periods, otherwise
 W<sub>cubic</sub>(*t*) might be very high after restarting from these

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1014,7 +1014,8 @@ A flow is application-limited if it is currently sending
 less than what is allowed by the congestion window.
 This can happen if the flow is limited by either the
 sender application or the receiver application (via the receiver
-advertised window) and thus sends less data than what is allowed by the sender's congestion window.
+advertised window) and thus sends less data than what is allowed by
+the sender's congestion window.
 
 CUBIC does not increase its congestion window if a flow is application-limited.
 {{win-inc}} requires that *t* in {{eq1}} does not include

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1011,7 +1011,7 @@ This is not considered in the current CUBIC design.
 ## Behavior for Application-Limited Flows {#app-limited}
 
 A flow is application-limited if it is currently sending
-less than is allowed by the congestion window.
+less than what is allowed by the congestion window.
 This can happen if the flow is limited by either the
 sender application or the receiver application (via the receiver
 advertised window) instead of the sender's congestion window.

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1014,7 +1014,7 @@ A flow is application-limited if it is currently sending
 less than what is allowed by the congestion window.
 This can happen if the flow is limited by either the
 sender application or the receiver application (via the receiver
-advertised window) instead of the sender's congestion window.
+advertised window) and thus sends less data than what is allowed by the sender's congestion window.
 
 CUBIC does not increase its congestion window if a flow is application-limited.
 {{win-inc}} requires that *t* in {{eq1}} does not include

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -486,8 +486,8 @@ cwnd                          &
 {: artwork-align="center" }
 
 The elapsed time *t* in {{eq1}} MUST NOT include periods during
-which *cwnd* has not been updated due to an application limit (see
-{{app-limited}}).
+which *cwnd* has not been updated due application-limited behavior
+(see {{app-limited}}).
 
 Depending on the value of the current congestion window size *cwnd*,
 CUBIC runs in three different regions:
@@ -1010,8 +1010,14 @@ This is not considered in the current CUBIC design.
 
 ## Behavior for Application-Limited Flows {#app-limited}
 
-CUBIC does not increase its congestion window size if a flow is
-currently limited by the application instead of the congestion window.
+A flow is application-limited if it is currently sending
+less than is allowed by the congestion window.
+This can happen if the flow is limited by either the
+sender application or the receiver application (via the receiver
+advertised window) instead of the sender's congestion window.
+
+CUBIC does not 
+increase its congestion window if a flow is application-limited.
 {{win-inc}} requires that *t* in {{eq1}} does not include
 application-limited periods, such as idle periods, otherwise
 W<sub>cubic</sub>(*t*) might be very high after restarting from these

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -486,7 +486,7 @@ cwnd                          &
 {: artwork-align="center" }
 
 The elapsed time *t* in {{eq1}} MUST NOT include periods during
-which *cwnd* has not been updated due application-limited behavior
+which *cwnd* has not been updated due to application-limited behavior
 (see {{app-limited}}).
 
 Depending on the value of the current congestion window size *cwnd*,


### PR DESCRIPTION
Clarify the meaning of "application-limited" to explicitly
mention that this can include slow sender applicaitons
or slow receiver applications.

Matt Olson notes in Issue #137:

  It seems like usually "app-limited" refers only to the local app, 
  but if the peer's receive window limits the connection's send 
  rate then we have the same problem where CWnd can grow
 arbitrarily. So, is "app-limited" supposed to also refer to the peer's
 receive window? If so, then this should probably be spelled out.

So we should be explicit that application-limited can refer to sender
or receiver apps that are slower than what cwnd allows.

We should particularly clarify this because the text on this topic
in 7661 is buggy, when it says:

   "application-limited period" for the time when the sender sends less
  than is allowed by the congestion or receiver windows.

This RFC 7661 text is buggy because if the receiver window is
smaller than the congestion window, and the sender sends
an amount equal to the receiver window, then the flow is
application-limited (it is limited by the receiver and receiver
advertised window instead of cwnd).