### PR TITLE
restrict use of cwnd directly on a congestion event

### DIFF
--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -663,19 +663,26 @@ or periods when unable to send at the full rate permitted by *cwnd*
 may easily encounter notable variations in the volume of data sent
 from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
-much lower value than necessary. Some implementations of CUBIC currently
-use *cwnd* instead of *flight_size* when calculating a new *ssthresh*
-using {{eqssthresh}}. The implementations that use *cwnd* directly MUST
-use other measures to not allow *cwnd* to grow when *flight_size* is less
-than *cwnd/2*. Both these approaches can result in suboptimal
-performance when *flight_size* is significantly lower than *cwnd* at the
-time of a congestion event. To mitigate this issue, the mechanisms described
-in {{?RFC7661}} can be used as it would allow using a value between *cwnd*
+much lower value than necessary. To avoid suboptimal performance with
+such applications, the mechanisms described in {{?RFC7661}} can be used
+to mitigate this issue as it would allow using a value between *cwnd*
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}.
 The congestion window growth mechanism defined in {{?RFC7661}} is safe
 to use even when *cwnd* is greater than the receive window as it
 validates *cwnd* based on the amount of data acknowledged by the network
 in an RTT which implicitly accounts for the allowed receive window.
+Some implementations of CUBIC currently use *cwnd* instead of *flight_size*
+when calculating a new *ssthresh* using {{eqssthresh}}. The implementations
+that use *cwnd* MUST use other measures to not allow *cwnd* to grow when
+bytes in flight is smaller than *cwnd*. That also effectively avoids *cwnd*
+from growing beyond the receive window. Such measures are important to
+prevent a CUBIC sender from using an arbitrarily high *cwnd* value in
+calculating the new value for *ssthresh* and *cwnd* when a congestion
+event is signalled, but it is not as robust as the mechanisms described
+in {{?RFC7661}}.
+Likewise, a QUIC sender that uses *cwnd* to calculate a new value
+for the congestion window and slow-start threshold on a congestion
+event is required to apply similar mechanisms {{!RFC9002}}.
 
 ~~~ math
 \begin{array}{lll}

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -1166,7 +1166,7 @@ These individuals suggested improvements to this document:
   fast convergence case
   ([#146](https://github.com/NTAP/rfc8312bis/pull/146))
 - Restrict use of *cwnd* directly on a congestion event
-  ([#14x](https://github.com/NTAP/rfc8312bis/pull/14x))
+  ([#148](https://github.com/NTAP/rfc8312bis/pull/148))
 
 ## Since draft-ietf-tcpm-rfc8312bis-07
 

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -669,8 +669,8 @@ using {{eqssthresh}}. The implementations that use *cwnd* directly MUST
 use other measures to not allow *cwnd* to grow when *flight_size* is less
 than *cwnd/2*. Both these approaches can result in suboptimal
 performance when *flight_size* is significantly lower than *cwnd* at the
-time of a congestion event. We recommend the mechanisms described in {{?RFC7661}}
-to mitigate this issue as it would allow using a value between *cwnd*
+time of a congestion event. To mitigate this issue, the mechanisms described
+in {{?RFC7661}} can be used as it would allow using a value between *cwnd*
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}.
 The congestion window growth mechanism defined in {{?RFC7661}} is safe
 to use even when *cwnd* is greater than the receive window as it

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -667,7 +667,7 @@ much lower value than necessary. Some implementations of CUBIC currently
 use *cwnd* instead of *flight_size* when calculating a new *ssthresh*
 using {{eqssthresh}}. The implementations that use *cwnd* directly MUST
 use other measures to not allow *cwnd* to grow when *flight_size* is less
-than *1/2* of the *cwnd*. Both these approaches can result in suboptimal
+than *cwnd/2*. Both these approaches can result in suboptimal
 performance when *flight_size* is significantly lower than *cwnd* at the
 time of a congestion event. We recommend the mechanisms described in {{?RFC7661}}
 to mitigate this issue as it would allow using a value between *cwnd*

--- a/draft-ietf-tcpm-rfc8312bis.md
+++ b/draft-ietf-tcpm-rfc8312bis.md
@@ -663,16 +663,19 @@ or periods when unable to send at the full rate permitted by *cwnd*
 may easily encounter notable variations in the volume of data sent
 from one RTT to another, resulting in *flight_size* that is significantly
 less than *cwnd* on a congestion event. This may decrease *cwnd* to a
-much lower value than necessary. To avoid suboptimal performance with
-such applications, the mechanisms described in {{?RFC7661}} can be used
+much lower value than necessary. Some implementations of CUBIC currently
+use *cwnd* instead of *flight_size* when calculating a new *ssthresh*
+using {{eqssthresh}}. The implementations that use *cwnd* directly MUST
+use other measures to not allow *cwnd* to grow when *flight_size* is less
+than *1/2* of the *cwnd*. Both these approaches can result in suboptimal
+performance when *flight_size* is significantly lower than *cwnd* at the
+time of a congestion event. We recommend the mechanisms described in {{?RFC7661}}
 to mitigate this issue as it would allow using a value between *cwnd*
 and *flight_size* to calculate the new *ssthresh* in {{eqssthresh}}.
 The congestion window growth mechanism defined in {{?RFC7661}} is safe
 to use even when *cwnd* is greater than the receive window as it
 validates *cwnd* based on the amount of data acknowledged by the network
 in an RTT which implicitly accounts for the allowed receive window.
-Some implementations of CUBIC currently use *cwnd* instead of *flight_size*
-when calculating a new *ssthresh* using {{eqssthresh}}.
 
 ~~~ math
 \begin{array}{lll}
@@ -1162,6 +1165,8 @@ These individuals suggested improvements to this document:
   than cwnd >= W_max, since these are different in the
   fast convergence case
   ([#146](https://github.com/NTAP/rfc8312bis/pull/146))
+- Restrict use of *cwnd* directly on a congestion event
+  ([#14x](https://github.com/NTAP/rfc8312bis/pull/14x))
 
 ## Since draft-ietf-tcpm-rfc8312bis-07
 


### PR DESCRIPTION
Based on Markku's proposed text regarding current implementations of Cubic that use cwnd directly on a congestion event.